### PR TITLE
v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cowvec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "digest"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,26 +327,16 @@ dependencies = [
 
 [[package]]
 name = "ramhorns"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "cowvec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ramhorns-derive 0.3.0",
 ]
 
 [[package]]
 name = "ramhorns-derive"
-version = "0.2.0"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ramhorns-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.3.0"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -544,7 +539,7 @@ dependencies = [
  "askama 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mustache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns 0.2.0",
+ "ramhorns 0.3.0",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "wearte 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -735,6 +730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cowvec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "81c2b93d5271df54c9855b80088f0c46dc6d56ad0db88bbb5c1c370a5d260dfc"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -765,7 +761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum ramhorns-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6350daedf0008c22dfd44d2b651b642c42ff158c300bfe3f376576ad7f2be5e5"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,11 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cowvec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "digest"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,7 +324,6 @@ dependencies = [
 name = "ramhorns"
 version = "0.3.0"
 dependencies = [
- "cowvec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ramhorns-derive 0.3.0",
 ]
@@ -730,7 +724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum cowvec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "81c2b93d5271df54c9855b80088f0c46dc6d56ad0db88bbb5c1c370a5d260dfc"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ What else do you want, a sticker?
 
 ```
 [dependencies]
-ramhorns = "0.2"
+ramhorns = "0.3"
 ```
 
 ### Example
 
 ```rust
-use ramhorns::{Template, Context};
+use ramhorns::{Template, Content};
 
-#[derive(Context)]
+#[derive(Content)]
 struct Post<'a> {
     title: &'a str,
     teaser: &'a str,
 }
 
-#[derive(Context)]
+#[derive(Content)]
 struct Blog<'a> {
     title: String,        // Strings are cool
     posts: Vec<Post<'a>>, // &'a [Post<'a>] would work too
@@ -45,7 +45,7 @@ let source ="<h1>{{title}}</h1>\
              {{#posts}}<article><h2>{{title}}</h2><p>{{teaser}}</p></article>{{/posts}}\
              {{^posts}}<p>No posts yet :(</p>{{/posts}}";
 
-let tpl = Template::new(source);
+let tpl = Template::new(source).unwrap();
 
 let rendered = tpl.render(&Blog {
     title: "My Awesome Blog!".to_string(),

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ What else do you want, a sticker?
 
 ### Cargo
 
-```
+```toml
 [dependencies]
 ramhorns = "0.3"
 ```

--- a/ramhorns-derive/Cargo.toml
+++ b/ramhorns-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns-derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"

--- a/ramhorns-derive/src/lib.rs
+++ b/ramhorns-derive/src/lib.rs
@@ -29,9 +29,9 @@ use std::hash::Hasher;
 
 type UnitFields = Punctuated<Field, Comma>;
 
-#[proc_macro_derive(Context)]
-pub fn logos(input: TokenStream) -> TokenStream {
-    let item: ItemStruct = syn::parse(input).expect("#[derive(Context)] can be only applied to structs");
+#[proc_macro_derive(Content)]
+pub fn content_derive(input: TokenStream) -> TokenStream {
+    let item: ItemStruct = syn::parse(input).expect("#[derive(Content)] can be only applied to structs");
 
     // panic!("{:#?}", item);
 
@@ -100,7 +100,7 @@ pub fn logos(input: TokenStream) -> TokenStream {
 
     // FIXME: decouple lifetimes from actual generics with trait boundaries
     let tokens = quote! {
-        impl#generics ramhorns::Context for #name#generics {
+        impl#generics ramhorns::Content for #name#generics {
             fn capacity_hint(&self, tpl: &ramhorns::Template) -> usize {
                 tpl.capacity_hint() #( + self.#fields.capacity_hint(tpl) )*
             }

--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["template-engine"]
 
 [dependencies]
 fnv = "1.0"
-cowvec = "0.1"
 ramhorns-derive = { path = "../ramhorns-derive", optional = true }
 # ramhorns-derive = { version = "0.3.0", optional = true }
 

--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"
@@ -13,7 +13,9 @@ categories = ["template-engine"]
 
 [dependencies]
 fnv = "1.0"
-ramhorns-derive = { version = "0.2.0", optional = true }
+cowvec = "0.1"
+ramhorns-derive = { path = "../ramhorns-derive", optional = true }
+# ramhorns-derive = { version = "0.3.0", optional = true }
 
 [features]
 default = ["export_derive"]

--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -12,14 +12,14 @@ use crate::encoding::Encoder;
 
 /// Trait allowing the rendering to quickly access data stored in the type that
 /// implements it. You needn't worry about implementing it, in virtually all
-/// cases the `#[derive(Context)]` attribute above your types should be sufficient.
-pub trait Context: Sized {
-    /// Marks whether this context is truthy. Used when attempting to render a section.
+/// cases the `#[derive(Content)]` attribute above your types should be sufficient.
+pub trait Content: Sized {
+    /// Marks whether this content is truthy. Used when attempting to render a section.
     fn is_truthy(&self) -> bool {
         true
     }
 
-    /// How much capacity is _likely_ required for all the data in this `Context`
+    /// How much capacity is _likely_ required for all the data in this `Content`
     /// for a given `Template`.
     fn capacity_hint(&self, _tpl: &Template) -> usize {
         0
@@ -106,7 +106,7 @@ pub trait Context: Sized {
     }
 }
 
-impl Context for &str {
+impl Content for &str {
     fn is_truthy(&self) -> bool {
         self.len() != 0
     }
@@ -130,7 +130,7 @@ impl Context for &str {
     }
 }
 
-impl Context for String {
+impl Content for String {
     fn is_truthy(&self) -> bool {
         self.len() != 0
     }
@@ -154,7 +154,7 @@ impl Context for String {
     }
 }
 
-impl Context for bool {
+impl Content for bool {
     fn is_truthy(&self) -> bool {
         *self
     }
@@ -178,7 +178,7 @@ impl Context for bool {
 macro_rules! impl_number_types {
     ($( $ty:ty ),*) => {
         $(
-            impl Context for $ty {
+            impl Content for $ty {
                 fn is_truthy(&self) -> bool {
                     *self != 0 as $ty
                 }
@@ -201,7 +201,7 @@ macro_rules! impl_number_types {
 
 impl_number_types!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
 
-impl<T: Context> Context for Option<T> {
+impl<T: Content> Content for Option<T> {
     fn is_truthy(&self) -> bool {
         self.is_some()
     }
@@ -247,7 +247,7 @@ impl<T: Context> Context for Option<T> {
     }
 }
 
-impl<T: Context, U> Context for Result<T, U> {
+impl<T: Content, U> Content for Result<T, U> {
     fn is_truthy(&self) -> bool {
         self.is_ok()
     }
@@ -293,7 +293,7 @@ impl<T: Context, U> Context for Result<T, U> {
     }
 }
 
-impl<T: Context> Context for Vec<T> {
+impl<T: Content> Content for Vec<T> {
     fn is_truthy(&self) -> bool {
         self.len() != 0
     }
@@ -310,7 +310,7 @@ impl<T: Context> Context for Vec<T> {
     }
 }
 
-impl<T: Context> Context for &[T] {
+impl<T: Content> Content for &[T] {
     fn is_truthy(&self) -> bool {
         self.len() != 0
     }

--- a/ramhorns/src/error.rs
+++ b/ramhorns/src/error.rs
@@ -6,8 +6,12 @@ pub enum Error {
     /// There was an error with the IO (only happens when parsing a file)
     Io(io::Error),
 
-    /// There was a parsing error.
-    ParsingError,
+    /// Parser was expecting a tag closing a section `{{/foo}}`,
+    /// but never found it or found a different one.
+    UnclosedSection(Box<str>),
+
+    /// Parser was expecting to find the closing braces of a tag `}}`, but never found it.
+    UnclosedTag,
 }
 
 impl From<io::Error> for Error {
@@ -19,8 +23,26 @@ impl From<io::Error> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::Io(err) => err.fmt(f),
-            Error::ParsingError => write!(f, "There was an error parsing the template!"),
+            Error::Io(err) => {
+                err.fmt(f)
+            },
+            Error::UnclosedSection(name) => {
+                write!(f, "Section not closed properly, was expecting {{{{/{}}}}}", name)
+            },
+            Error::UnclosedTag => {
+                write!(f, "Couldn't find closing braces matching opening braces")
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn displays_properly() {
+        assert_eq!(Error::UnclosedSection("foo".into()).to_string(), "Section not closed properly, was expecting {{/foo}}");
+        assert_eq!(Error::UnclosedTag.to_string(), "Couldn't find closing braces matching opening braces");
     }
 }

--- a/ramhorns/src/error.rs
+++ b/ramhorns/src/error.rs
@@ -1,0 +1,26 @@
+use std::{io, fmt};
+
+/// Error type used that can be emitted during template parsing.
+#[derive(Debug)]
+pub enum Error {
+    /// There was an error with the IO (only happens when parsing a file)
+    Io(io::Error),
+
+    /// There was a parsing error.
+    ParsingError,
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::Io(err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(err) => err.fmt(f),
+            Error::ParsingError => write!(f, "There was an error parsing the template!"),
+        }
+    }
+}

--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -28,15 +28,15 @@
 //! ## Example
 //!
 //! ```rust
-//! use ramhorns::{Template, Context};
+//! use ramhorns::{Template, Content};
 //!
-//! #[derive(Context)]
+//! #[derive(Content)]
 //! struct Post<'a> {
 //!     title: &'a str,
 //!     teaser: &'a str,
 //! }
 //!
-//! #[derive(Context)]
+//! #[derive(Content)]
 //! struct Blog<'a> {
 //!     title: String,        // Strings are cool
 //!     posts: Vec<Post<'a>>, // &'a [Post<'a>] would work too
@@ -47,7 +47,7 @@
 //!              {{#posts}}<article><h2>{{title}}</h2><p>{{teaser}}</p></article>{{/posts}}\
 //!              {{^posts}}<p>No posts yet :(</p>{{/posts}}";
 //!
-//! let tpl = Template::new(source);
+//! let tpl = Template::new(source).unwrap();
 //!
 //! let rendered = tpl.render(&Blog {
 //!     title: "My Awesome Blog!".to_string(),
@@ -76,13 +76,15 @@
 
 #![warn(missing_docs)]
 
+mod content;
+mod error;
 mod template;
-mod context;
 
 pub mod encoding;
 
+pub use error::Error;
 pub use template::{Template, Section};
-pub use context::Context;
+pub use content::Content;
 
 #[cfg(feature = "export_derive")]
-pub use ramhorns_derive::Context;
+pub use ramhorns_derive::Content;

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -10,6 +10,7 @@
 mod parse;
 mod section;
 
+use std::borrow::Cow;
 use std::hash::Hasher;
 use std::fs::File;
 use std::io;
@@ -19,7 +20,6 @@ use crate::{Content, Error};
 use crate::encoding::{Encoder, EscapingIOEncoder};
 
 use fnv::FnvHasher;
-use cowvec::CowStr;
 
 pub use section::Section;
 
@@ -36,7 +36,7 @@ pub struct Template<'tpl> {
     tail: &'tpl str,
 
     /// Source from which this template was parsed.
-    source: CowStr<'tpl>,
+    source: Cow<'tpl, str>,
 }
 
 impl<'tpl> Template<'tpl> {
@@ -46,7 +46,7 @@ impl<'tpl> Template<'tpl> {
     /// + If `Source` is a `String`, this `Template` will take it's ownership (The `'tpl` lifetime will be `'static`).
     pub fn new<Source>(source: Source) -> Result<Self, Error>
     where
-        Source: Into<CowStr<'tpl>>,
+        Source: Into<Cow<'tpl, str>>,
     {
         let mut tpl = Template {
             blocks: Vec::new(),
@@ -75,7 +75,7 @@ impl<'tpl> Template<'tpl> {
 
         let mut last = 0;
 
-        tpl.parse(source, &mut iter, &mut last, None);
+        tpl.parse(source, &mut iter, &mut last, None)?;
         tpl.tail = &source[last..];
 
         Ok(tpl)

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -1,5 +1,5 @@
 use super::{Block, Tag};
-use crate::Context;
+use crate::Content;
 use crate::encoding::Encoder;
 
 /// A section of a `Template` that can be rendered individually, usually delimited by
@@ -16,11 +16,11 @@ impl<'section> Section<'section> {
         }
     }
 
-    /// Render this section once to the provided `Encoder`. Some `Context`s will call
+    /// Render this section once to the provided `Encoder`. Some `Content`s will call
     /// this method multiple times (to render a list of elements).
     pub fn render_once<C, E>(&self, ctx: &C, encoder: &mut E) -> Result<(), E::Error>
     where
-        C: Context,
+        C: Content,
         E: Encoder,
     {
         let mut index = 0;

--- a/tests/benches/main.rs
+++ b/tests/benches/main.rs
@@ -2,13 +2,13 @@
 extern crate test;
 
 use test::{Bencher, black_box};
-use ramhorns::Context;
+use ramhorns::Content;
 use serde_derive::Serialize;
 use askama::Template;
 
 static SOURCE: &str = "<title>{{title}}</title><h1>{{ title }}</h1><div>{{{body}}}</div>";
 
-#[derive(Context, Serialize, Template)]
+#[derive(Content, Serialize, Template)]
 #[template(source = "<title>{{title}}</title><h1>{{ title }}</h1><div>{{body|safe}}</div>", ext = "html")]
 struct Post<'a> {
     title: &'a str,
@@ -19,7 +19,7 @@ struct Post<'a> {
 fn a_simple_ramhorns(b: &mut Bencher) {
     use ramhorns::Template;
 
-    let tpl = Template::new(SOURCE);
+    let tpl = Template::new(SOURCE).unwrap();
     let post = Post {
         title: "Hello, Ramhorns!",
         body: "This is a really simple test of the rendering!",


### PR DESCRIPTION
+ [x] Rename `Context` to `Content`.
+ [x] Allow for a `Template<'static>` that owns it's data to be created from a `String`s using `new`.
+ [x] Add `Template::from_file` and `Template::render_to_file` API.
+ [x] `Template::new` to return a `Result<Template, Error>`.
+ [x] Return informative errors from parsing.