### PR TITLE
Add support for HashMap and BTreeMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,26 +322,15 @@ dependencies = [
 
 [[package]]
 name = "ramhorns"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ramhorns-derive 0.4.0",
 ]
 
 [[package]]
 name = "ramhorns-derive"
-version = "0.3.0"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ramhorns-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.0"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -544,7 +533,7 @@ dependencies = [
  "askama 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mustache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns 0.3.0",
+ "ramhorns 0.4.0",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "wearte 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,7 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum ramhorns-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04f571a9009f974835f90e4a3aec5e75510aef164eb598e7bdffe1cbbab4f41b"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What else do you want, a sticker?
 
 ```toml
 [dependencies]
-ramhorns = "0.3"
+ramhorns = "0.4"
 ```
 
 ### Example

--- a/ramhorns-derive/Cargo.toml
+++ b/ramhorns-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns-derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"

--- a/ramhorns-derive/src/lib.rs
+++ b/ramhorns-derive/src/lib.rs
@@ -105,7 +105,7 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 tpl.capacity_hint() #( + self.#fields.capacity_hint(tpl) )*
             }
 
-            fn render_field_escaped<E>(&self, hash: u64, encoder: &mut E) -> Result<(), E::Error>
+            fn render_field_escaped<E>(&self, hash: u64, _: &str, encoder: &mut E) -> Result<(), E::Error>
             where
                 E: ramhorns::encoding::Encoder,
             {
@@ -115,7 +115,7 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn render_field_unescaped<E>(&self, hash: u64, encoder: &mut E) -> Result<(), E::Error>
+            fn render_field_unescaped<E>(&self, hash: u64, _: &str, encoder: &mut E) -> Result<(), E::Error>
             where
                 E: ramhorns::encoding::Encoder,
             {
@@ -125,7 +125,7 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn render_field_section<'section, E>(&self, hash: u64, section: ramhorns::Section<'section>, encoder: &mut E) -> Result<(), E::Error>
+            fn render_field_section<'section, E>(&self, hash: u64, _: &str, section: ramhorns::Section<'section>, encoder: &mut E) -> Result<(), E::Error>
             where
                 E: ramhorns::encoding::Encoder,
             {
@@ -135,7 +135,7 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn render_field_inverse<'section, E>(&self, hash: u64, section: ramhorns::Section<'section>, encoder: &mut E) -> Result<(), E::Error>
+            fn render_field_inverse<'section, E>(&self, hash: u64, _: &str, section: ramhorns::Section<'section>, encoder: &mut E) -> Result<(), E::Error>
             where
                 E: ramhorns::encoding::Encoder,
             {

--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"
@@ -13,7 +13,8 @@ categories = ["template-engine"]
 
 [dependencies]
 fnv = "1.0"
-ramhorns-derive = { version = "0.3.0", optional = true }
+# ramhorns-derive = { version = "0.4.0", optional = true }
+ramhorns-derive = { path = "../ramhorns-derive", optional = true }
 
 [features]
 default = ["export_derive"]

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -31,15 +31,15 @@ impl<'section> Section<'section> {
             encoder.write_unescaped(block.html)?;
 
             match block.tag {
-                Tag::Escaped => ctx.render_field_escaped(block.hash, encoder)?,
-                Tag::Unescaped => ctx.render_field_unescaped(block.hash, encoder)?,
+                Tag::Escaped => ctx.render_field_escaped(block.hash, block.name, encoder)?,
+                Tag::Unescaped => ctx.render_field_unescaped(block.hash, block.name, encoder)?,
                 Tag::Section(count) => {
-                    ctx.render_field_section(block.hash, Section::new(&self.blocks[index..index + count]), encoder)?;
+                    ctx.render_field_section(block.hash, block.name, Section::new(&self.blocks[index..index + count]), encoder)?;
 
                     index += count;
                 },
                 Tag::Inverse(count) => {
-                    ctx.render_field_inverse(block.hash, Section::new(&self.blocks[index..index + count]), encoder)?;
+                    ctx.render_field_inverse(block.hash, block.name, Section::new(&self.blocks[index..index + count]), encoder)?;
 
                     index += count;
                 },

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -37,6 +37,42 @@ fn simple_render_to_writer() {
 }
 
 #[test]
+fn simple_render_hash_map() {
+    use std::collections::HashMap;
+
+    let source = "<title>{{title}}</title><h1>{{ title }}</h1><div>{{body}}</div>";
+    let tpl = Template::new(source).unwrap();
+
+    let mut map = HashMap::new();
+
+    map.insert("title", "Hello, Ramhorns!");
+    map.insert("body", "This is a test of rendering a template with a HashMap Content!");
+
+    let rendered = tpl.render(&map);
+
+    assert_eq!(&rendered, "<title>Hello, Ramhorns!</title><h1>Hello, Ramhorns!</h1>\
+                           <div>This is a test of rendering a template with a HashMap Content!</div>");
+}
+
+#[test]
+fn simple_render_btree_map() {
+    use std::collections::BTreeMap;
+
+    let source = "<title>{{title}}</title><h1>{{ title }}</h1><div>{{body}}</div>";
+    let tpl = Template::new(source).unwrap();
+
+    let mut map = BTreeMap::new();
+
+    map.insert("title", "Hello, Ramhorns!");
+    map.insert("body", "This is a test of rendering a template with a BTreeMap Content!");
+
+    let rendered = tpl.render(&map);
+
+    assert_eq!(&rendered, "<title>Hello, Ramhorns!</title><h1>Hello, Ramhorns!</h1>\
+                           <div>This is a test of rendering a template with a BTreeMap Content!</div>");
+}
+
+#[test]
 fn simple_render_with_comments() {
     let source = "<title>{{ ! ignore me }}{{title}}</title>{{!-- nothing to look at here --}}<h1>{{ title }}</h1><div>{{body}}</div>";
     let tpl = Template::new(source).unwrap();


### PR DESCRIPTION
+ Added `&str` name of the field to `Content` methods that need it. This is technically a breaking change, but it shouldn't really affect user code.
+ Added generic impls of `Content` for `HashMap` and `BTreeMap`.