### PR TITLE
Allow fields to reference parent content

### DIFF
--- a/ramhorns-derive/src/lib.rs
+++ b/ramhorns-derive/src/lib.rs
@@ -124,14 +124,6 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 tpl.capacity_hint() #( + self.#fields.capacity_hint(tpl) )*
             }
             
-            fn render_section<'section, 'content, E>(&'content self, mut section: ramhorns::Section<'section, 'content, E>, encoder: &mut E) -> Result<(), E::Error>
-            where
-        	'content: 'section,
-                E: ramhorns::encoding::Encoder,
-            {
-                section.render_once(self, encoder)
-            }
-
             fn render_field_escaped<E>(&self, hash: u64, _: &str, encoder: &mut E) -> Result<bool, E::Error>
             where
                 E: ramhorns::encoding::Encoder,
@@ -152,9 +144,9 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn render_field_section<'section, 'content, E>(&'content self, hash: u64, _: &str, section: ramhorns::Section<'section, 'content, E>, encoder: &mut E) -> Result<bool, E::Error>
+            fn render_field_section<'section, P, E>(&self, hash: u64, _: &str, section: ramhorns::Section<'section, P>, encoder: &mut E) -> Result<bool, E::Error>
             where
-        	'content: 'section,
+            	P: ramhorns::Content + Copy + 'section,
                 E: ramhorns::encoding::Encoder,
             {
                 match hash {
@@ -163,9 +155,9 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn render_field_inverse<'section, 'content, E>(&'content self, hash: u64, _: &str, section: ramhorns::Section<'section, 'content, E>, encoder: &mut E) -> Result<bool, E::Error>
+            fn render_field_inverse<'section, P, E>(&self, hash: u64, _: &str, section: ramhorns::Section<'section, P>, encoder: &mut E) -> Result<bool, E::Error>
             where
-            	'content: 'section,
+            	P: ramhorns::Content + Copy + 'section,
                 E: ramhorns::encoding::Encoder,
             {
                 match hash {

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -115,7 +115,7 @@ impl<'tpl> Template<'tpl> {
         let mut buf = String::with_capacity(capacity);
 
         // Ignore the result, cannot fail
-        let _ = Section::new(&self.blocks).render_once(content, &mut buf);
+        let _ = Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut buf);
 
         buf
     }
@@ -127,7 +127,7 @@ impl<'tpl> Template<'tpl> {
         C: Content,
     {
         let mut encoder = EscapingIOEncoder::new(writer);
-        Section::new(&self.blocks).render_once(content, &mut encoder)
+        Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut encoder)
     }
 
     /// Render this `Template` with a given `Content` to a file.
@@ -141,7 +141,7 @@ impl<'tpl> Template<'tpl> {
         let writer = BufWriter::new(File::create(path)?);
         let mut encoder = EscapingIOEncoder::new(writer);
 
-        Section::new(&self.blocks).render_once(content, &mut encoder)
+        Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut encoder)
     }
 
     /// Get a reference to a source this `Template` was created from.
@@ -195,7 +195,7 @@ impl Templates {
                 let path = entry?.path();
                 if path.is_dir() {
                     load_folder(&path, templates)?;
-                } else if path.extension().unwrap_or("".as_ref()) == "html" {
+                } else if path.extension().unwrap_or_else(|| "".as_ref()) == "html" {
                     let name = path
                         .strip_prefix(&templates.dir)
                         .unwrap_or(&path)

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -115,7 +115,7 @@ impl<'tpl> Template<'tpl> {
         let mut buf = String::with_capacity(capacity);
 
         // Ignore the result, cannot fail
-        let _ = Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut buf);
+        let _ = Section::new(&self.blocks).render_once(content, &mut buf);
 
         buf
     }
@@ -127,7 +127,7 @@ impl<'tpl> Template<'tpl> {
         C: Content,
     {
         let mut encoder = EscapingIOEncoder::new(writer);
-        Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut encoder)
+        Section::new(&self.blocks).render_once(content, &mut encoder)
     }
 
     /// Render this `Template` with a given `Content` to a file.
@@ -141,7 +141,7 @@ impl<'tpl> Template<'tpl> {
         let writer = BufWriter::new(File::create(path)?);
         let mut encoder = EscapingIOEncoder::new(writer);
 
-        Section::new(&self.blocks, &mut Vec::with_capacity(5)).render_once(content, &mut encoder)
+        Section::new(&self.blocks).render_once(content, &mut encoder)
     }
 
     /// Get a reference to a source this `Template` was created from.

--- a/ramhorns/src/template/parse.rs
+++ b/ramhorns/src/template/parse.rs
@@ -7,7 +7,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Ramhorns.  If not, see <http://www.gnu.org/licenses/>
 
-use super::{Block, Error, Tag, Template, Partials};
+use super::{Block, Error, Partials, Tag, Template};
 
 impl<'tpl> Template<'tpl> {
     pub(crate) fn parse(
@@ -17,8 +17,7 @@ impl<'tpl> Template<'tpl> {
         last: &mut usize,
         until: Option<&'tpl str>,
         partials: &mut impl Partials<'tpl>,
-    ) -> Result<usize, Error>
-    {
+    ) -> Result<usize, Error> {
         let blocks_at_start = self.blocks.len();
 
         while let Some((start, bytes)) = iter.next() {
@@ -80,8 +79,7 @@ impl<'tpl> Template<'tpl> {
 
                         match tag {
                             Tag::Section(_) | Tag::Inverse(_) => {
-                                let count =
-                                    self.parse(source, iter, last, Some(name), partials)?;
+                                let count = self.parse(source, iter, last, Some(name), partials)?;
 
                                 match self.blocks[insert_index].tag {
                                     Tag::Section(ref mut c) | Tag::Inverse(ref mut c) => *c = count,

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -8,30 +8,32 @@
 // along with Ramhorns.  If not, see <http://www.gnu.org/licenses/>
 
 use super::{Block, Tag};
+use crate::content::EncContent;
 use crate::encoding::Encoder;
 use crate::Content;
 
 /// A section of a `Template` that can be rendered individually, usually delimited by
 /// `{{#section}} ... {{/section}}` tags.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Section<'section> {
+pub struct Section<'section, 'content: 'section, E: Encoder> {
     blocks: &'section [Block<'section>],
+    stack: &'section mut Vec<&'content dyn EncContent<E>>,
 }
 
-impl<'section> Section<'section> {
-    pub(crate) const fn new(
+impl<'section, 'content: 'section, E: Encoder> Section<'section, 'content, E> {
+    pub(crate) fn new(
         blocks: &'section [Block<'section>],
+        stack: &'section mut Vec<&'content dyn EncContent<E>>,
     ) -> Self {
-        Self { blocks }
+        Self { blocks, stack }
     }
 
     /// Render this section once to the provided `Encoder`. Some `Content`s will call
     /// this method multiple times (to render a list of elements).
-    pub fn render_once<C, E>(&self, content: &C, encoder: &mut E) -> Result<(), E::Error>
-    where
-        C: Content,
-        E: Encoder,
-    {
+    pub fn render_once<C: Content>(
+        &mut self,
+        content: &'content C,
+        encoder: &mut E,
+    ) -> Result<(), E::Error> {
         let mut index = 0;
 
         while let Some(block) = self.blocks.get(index) {
@@ -40,27 +42,71 @@ impl<'section> Section<'section> {
             encoder.write_unescaped(block.html)?;
 
             match block.tag {
-                Tag::Escaped => content.render_field_escaped(block.hash, block.name, encoder)?,
+                Tag::Escaped => {
+                    if !content.render_field_escaped(block.hash, block.name, encoder)? {
+                        for parent in self.stack.iter().rev() {
+                            if parent.render_field_escaped(block.hash, block.name, encoder)? {
+                                break;
+                            }
+                        }
+                    }
+                }
                 Tag::Unescaped => {
-                    content.render_field_unescaped(block.hash, block.name, encoder)?
+                    if !content.render_field_unescaped(block.hash, block.name, encoder)? {
+                        for parent in self.stack.iter().rev() {
+                            if parent.render_field_unescaped(block.hash, block.name, encoder)? {
+                                break;
+                            }
+                        }
+                    }
                 }
                 Tag::Section(count) => {
-                    content.render_field_section(
+                    self.stack.push(content);
+                    if !content.render_field_section(
                         block.hash,
                         block.name,
-                        Section::new(&self.blocks[index..index + count]),
+                        Section::new(&self.blocks[index..index + count], self.stack),
                         encoder,
-                    )?;
+                    )? && self.stack.len() > 1
+                    {
+                        // Can't use an iterator since it references stack, which is mutable
+                        for i in (0..self.stack.len() - 1).rev() {
+                            if self.stack[i].render_field_section(
+                                block.hash,
+                                block.name,
+                                Section::new(&self.blocks[index..index + count], self.stack),
+                                encoder,
+                            )? {
+                                break;
+                            };
+                        }
+                    };
+                    self.stack.pop();
 
                     index += count;
                 }
                 Tag::Inverse(count) => {
-                    content.render_field_inverse(
+                    self.stack.push(content);
+                    if !content.render_field_inverse(
                         block.hash,
                         block.name,
-                        Section::new(&self.blocks[index..index + count]),
+                        Section::new(&self.blocks[index..index + count], self.stack),
                         encoder,
-                    )?;
+                    )? && self.stack.len() > 1
+                    {
+                        // Can't use an iterator since it references stack, which is mutable
+                        for i in (0..self.stack.len() - 1).rev() {
+                            if self.stack[i].render_field_inverse(
+                                block.hash,
+                                block.name,
+                                Section::new(&self.blocks[index..index + count], self.stack),
+                                encoder,
+                            )? {
+                                break;
+                            };
+                        }
+                    };
+                    self.stack.pop();
 
                     index += count;
                 }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -402,6 +402,55 @@ fn can_render_markdown() {
 }
 
 #[test]
+fn can_reference_parent_content() {
+    #[derive(Content)]
+    struct Grandpa<'a> {
+        name: &'a str,
+        son: Father<'a>,
+        hobbies: Vec<Hobby<'a>>,
+    }
+
+    #[derive(Content)]
+    struct Father<'a> {
+        title: &'a str,
+        grandson: Man<'a>,
+    }
+
+    #[derive(Content)]
+    struct Man<'a> {
+        favourite_lang: &'a str,
+    }
+
+    #[derive(Content)]
+    struct Hobby<'a> {
+        hobby: &'a str,
+    }
+
+    let tpl = Template::new(
+        "<h1>Grandpa</h1><p>He's got a son.{{#son}} He's got another son.{{#grandson}}
+        His favourite language is {{favourite_lang}}. People call his father {{title}} and his grandfather {{name}}.
+        Grandpa's hobbies are: <ul>{{#hobbies}}<li>{{hobby}}</li>{{/hobbies}}</ul>{{/grandson}}{{/son}}</p>").unwrap();
+
+    let html = tpl.render(&Grandpa {
+        name: "Jan",
+        son: Father {
+            title: "Sir",
+            grandson: Man {
+                favourite_lang: "Rust",
+            },
+        },
+        hobbies: vec![
+            Hobby {
+                hobby: "watching ducks",
+            },
+            Hobby { hobby: "petang" },
+        ],
+    });
+
+    assert_eq!(html, "<h1>Grandpa</h1><p>He\'s got a son. He\'s got another son.\n        His favourite language is Rust. People call his father Sir and his grandfather Jan.\n        Grandpa\'s hobbies are: <ul><li>watching ducks</li><li>petang</li></ul></p>");
+}
+
+#[test]
 fn simple_partials() {
     let tpl = Template::from_file("templates/layout.html").unwrap();
     let html = tpl.render(&"");


### PR DESCRIPTION
[Mustache specification](https://mustache.github.io/mustache.5.html) says:

> A {{name}} tag in a basic template will try to find the name key in the current context. If there is no name key, the parent contexts will be checked recursively. If the top context is reached and the name key is still not found, nothing will be rendered.

It's a situation that relatively often happens when designing a website (e.g. one may want to use the page title in one of it's subsections). This PR implements this functionality.

It does so via a helper `EncContent<E: Encoder>` trait, which is implemented for every `Content` and `Encoder` and wraps the functions to render fields. The parent contents are then stored in a stack of `&dyn EncContent<E>`, which is implemented as `&mut Vec` that the sections can share.
(`Content` contains generic methods, so it can't be turend into a trait object.)
This provides a slight slowdown for rendering, as the stack needs to be allocated, but it should be rather constant and in the magnitude of a few nanoseconds.

This PR introduces 2 breaking changes. One is the signature of section, which is now `Section<'section, 'content, E>` where `'content: 'section, E: Encoder`. This is necessary to be able to create the trait objects for the particular `Encoder` and to pass the borrow checker. (There may be a way to pass with less lifetime annotations, but I don't see it, as the reference to the stack is mutable.)
The second breaking change is the return type of `render_field_*` methods, which is now `Result<bool, E:Error>`, indicating whether the field was found in the current content. (This could theoretically be avoided by introducing a new error kind `FieldNotFound`, but that would make the code more verbose.)
As the users are note expected to implement the `Content` trait, the effect of these breaking changes should be minor. 

Additionally, the `Sized` restriction of `Content` is lifted, allowing it to be implemented for more types (`&T where T: Content`, also deriving for structs with smart pointer fields like `Box<[T]>` or `Cow<str>` now works).