### PR TITLE
0.6.1

### DIFF
--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"

--- a/ramhorns/src/error.rs
+++ b/ramhorns/src/error.rs
@@ -7,7 +7,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Ramhorns.  If not, see <http://www.gnu.org/licenses/>
 
-use std::{fmt, io};
+use std::{fmt, io, error};
 
 /// Error type used that can be emitted during template parsing.
 #[derive(Debug)]
@@ -28,6 +28,8 @@ pub enum Error {
     /// Attempted to load a partial outside of the templates folder
     IllegalPartial(Box<str>),
 }
+
+impl error::Error for Error {}
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -84,11 +84,9 @@ impl<'tpl> Template<'tpl> {
 
         let mut iter = source
             .as_bytes()
-            .get(..tpl.source.len().saturating_sub(1))
-            .unwrap_or(&[])
-            .iter()
-            .map(|b| unsafe { &*(b as *const u8 as *const [u8; 2]) }) // Because we iterate up till last byte,
-            .enumerate(); // this is safe.
+            .windows(2)
+            .map(|b| unsafe { &*(b.as_ptr() as *const [u8; 2]) }) // windows iterator makes this safe
+            .enumerate();
 
         let mut last = 0;
 


### PR DESCRIPTION
+ `Error` now implements `std::error::Error`.

Closes #15.