### PR TITLE
fix: Render inverse sections for missing fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "ramhorns"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -605,7 +605,7 @@ dependencies = [
  "askama 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mustache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns 0.7.0",
+ "ramhorns 0.7.1",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -113,7 +113,7 @@ impl<'tpl> Template<'tpl> {
         let mut buf = String::with_capacity(capacity);
 
         // Ignore the result, cannot fail
-        let _ = Section::new(&self.blocks).render_once(content, &mut buf);
+        let _ = Section::new(&self.blocks).with(content).render(&mut buf);
 
         buf
     }
@@ -125,7 +125,7 @@ impl<'tpl> Template<'tpl> {
         C: Content,
     {
         let mut encoder = EscapingIOEncoder::new(writer);
-        Section::new(&self.blocks).render_once(content, &mut encoder)
+        Section::new(&self.blocks).with(content).render(&mut encoder)
     }
 
     /// Render this `Template` with a given `Content` to a file.
@@ -139,7 +139,7 @@ impl<'tpl> Template<'tpl> {
         let writer = BufWriter::new(File::create(path)?);
         let mut encoder = EscapingIOEncoder::new(writer);
 
-        Section::new(&self.blocks).render_once(content, &mut encoder)
+        Section::new(&self.blocks).with(content).render(&mut encoder)
     }
 
     /// Get a reference to a source this `Template` was created from.

--- a/ramhorns/src/traits.rs
+++ b/ramhorns/src/traits.rs
@@ -170,11 +170,11 @@ where
     }
 
     #[inline]
-    fn render_field_section<'section, P, E>(
+    fn render_field_section<P, E>(
         &self,
         hash: u64,
         name: &str,
-        section: Section<'section, P>,
+        section: Section<P>,
         encoder: &mut E,
     ) -> Result<bool, E::Error>
     where
@@ -194,11 +194,11 @@ where
     }
 
     #[inline]
-    fn render_field_inverse<'section, P, E>(
+    fn render_field_inverse<P, E>(
         &self,
         hash: u64,
         name: &str,
-        section: Section<'section, P>,
+        section: Section<P>,
         encoder: &mut E,
     ) -> Result<bool, E::Error>
     where
@@ -208,7 +208,10 @@ where
         match self.3.render_field_inverse(hash, name, section, encoder) {
             Ok(false) => match self.2.render_field_inverse(hash, name, section, encoder) {
                 Ok(false) => match self.1.render_field_inverse(hash, name, section, encoder) {
-                    Ok(false) => self.0.render_field_inverse(hash, name, section, encoder),
+                    Ok(false) => match self.0.render_field_inverse(hash, name, section, encoder) {
+                        Ok(false) => section.render(encoder).map(|()| true),
+                        res => res,
+                    },
                     res => res,
                 },
                 res => res,

--- a/tests/benches/main.rs
+++ b/tests/benches/main.rs
@@ -64,6 +64,25 @@ fn c_simple_tera(b: &mut Bencher) {
 }
 
 #[bench]
+fn c_simple_tera_from_serialize(b: &mut Bencher) {
+    use tera::{Tera, Context};
+
+    let mut tera = Tera::new("templates/includes/*").unwrap();
+
+    tera.add_raw_template("t1", "<title>{{title}}</title><h1>{{ title }}</h1><div>{{body|safe}}</div>").unwrap();
+
+    let post = Post {
+        title: "Hello, Ramhorns!",
+        body: "This is a really simple test of the rendering!",
+    };
+    // let post = Context::from_serialize(&post).unwrap();
+
+    b.iter(|| {
+        black_box(tera.render("t1", &Context::from_serialize(&post).unwrap()).unwrap())
+    });
+}
+
+#[bench]
 fn d_simple_mustache(b: &mut Bencher) {
     let tpl = mustache::compile_str(SOURCE).unwrap();
 


### PR DESCRIPTION
[Actual fix](https://github.com/maciejhirsz/ramhorns/blob/59ba8aa6faa708af1d698041950a5c69080e43ed/ramhorns/src/traits.rs#L212), everything else is inconsequential refactoring to make things prettier/more consistent.