### PR TITLE
Allow Content to be implemented for unsized types

### DIFF
--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 /// Trait allowing the rendering to quickly access data stored in the type that
 /// implements it. You needn't worry about implementing it, in virtually all
 /// cases the `#[derive(Content)]` attribute above your types should be sufficient.
-pub trait Content: Sized {
+pub trait Content {
     /// Marks whether this content is truthy. Used when attempting to render a section.
     #[inline]
     fn is_truthy(&self) -> bool {
@@ -163,7 +163,7 @@ impl Content for () {
     }
 }
 
-impl Content for &str {
+impl Content for str {
     #[inline]
     fn is_truthy(&self) -> bool {
         !self.is_empty()
@@ -424,7 +424,7 @@ impl<T: Content> Content for Vec<T> {
     }
 }
 
-impl<T: Content> Content for &[T] {
+impl<T: Content> Content for [T] {
     #[inline]
     fn is_truthy(&self) -> bool {
         !self.is_empty()
@@ -590,7 +590,7 @@ where
 macro_rules! impl_pointer_types {
     ($( $ty:ty $(: $bounds:tt)? ),*) => {
         $(
-            impl<T: Content $(+ $bounds)?> Content for $ty {
+            impl<T: Content $(+ $bounds)? + ?Sized> Content for $ty {
                 #[inline]
                 fn is_truthy(&self) -> bool {
                     self.deref().is_truthy()

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -48,7 +48,7 @@ where
     #[inline]
     pub fn with<X>(self, content: &X) -> Section<'section, (C::I, C::J, C::K, &X)>
     where
-        X: Content,
+        X: Content + ?Sized,
     {
         Section {
             blocks: self.blocks,

--- a/ramhorns/src/traits.rs
+++ b/ramhorns/src/traits.rs
@@ -18,14 +18,14 @@ use crate::Content;
 /// so that self-referencing `Content`s don't blow up the stack on compilation.
 pub trait Combine {
     /// First type for the result tuple
-    type I: Content + Copy;
+    type I: Content + Copy + Sized;
     /// Second type for the result tuple
-    type J: Content + Copy;
+    type J: Content + Copy + Sized;
     /// Third type for the result tuple
-    type K: Content + Copy;
+    type K: Content + Copy + Sized;
 
     /// Combines current tuple with a new element.
-    fn combine<X: Content>(self, other: &X) -> (Self::I, Self::J, Self::K, &X);
+    fn combine<X: Content + ?Sized>(self, other: &X) -> (Self::I, Self::J, Self::K, &X);
 }
 
 /// Helper trait that re-exposes `render_field_x` methods of a `Content` trait,
@@ -100,7 +100,7 @@ impl Combine for () {
     type K = ();
 
     #[inline]
-    fn combine<X: Content>(self, other: &X) -> ((), (), (), &X) {
+    fn combine<X: Content + ?Sized>(self, other: &X) -> ((), (), (), &X) {
         ((), (), (), other)
     }
 }
@@ -109,27 +109,27 @@ impl ContentSequence for () {}
 
 impl<'tup, A, B, C, D> Combine for (A, B, C, &'tup D)
 where
-    A: Content + Copy,
-    B: Content + Copy,
-    C: Content + Copy,
-    D: Content,
+    A: Content + Copy + Sized,
+    B: Content + Copy + Sized,
+    C: Content + Copy + Sized,
+    D: Content + ?Sized,
 {
     type I = B;
     type J = C;
     type K = &'tup D;
 
     #[inline]
-    fn combine<X: Content>(self, other: &X) -> (B, C, &'tup D, &X) {
+    fn combine<X: Content + ?Sized>(self, other: &X) -> (B, C, &'tup D, &X) {
         (self.1, self.2, self.3, other)
     }
 }
 
 impl<A, B, C, D> ContentSequence for (A, B, C, &D)
 where
-    A: Content + Copy,
-    B: Content + Copy,
-    C: Content + Copy,
-    D: Content,
+    A: Content + Copy + Sized,
+    B: Content + Copy + Sized,
+    C: Content + Copy + Sized,
+    D: Content + ?Sized,
 {
     #[inline]
     fn render_field_escaped<E: Encoder>(


### PR DESCRIPTION
As per discussion in #20, this restores the generic `Content` implementation for smart pointer slices such as `Box<str>`.