### PR TITLE
Only add content to section if it contains fields

### DIFF
--- a/ramhorns-derive/src/lib.rs
+++ b/ramhorns-derive/src/lib.rs
@@ -125,6 +125,15 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
             fn capacity_hint(&self, tpl: &ramhorns::Template) -> usize {
                 tpl.capacity_hint() #( + self.#fields.capacity_hint(tpl) )*
             }
+            
+            #[inline]
+            fn render_section<C, E>(&self, section: ramhorns::Section<C>, encoder: &mut E) -> Result<(), E::Error>
+            where
+                C: ramhorns::traits::ContentSequence,
+                E: ramhorns::encoding::Encoder,
+            {
+                section.with(self).render(encoder)
+            }
 
             #[inline]
             fn render_field_escaped<E>(&self, hash: u64, _: &str, encoder: &mut E) -> Result<bool, E::Error>

--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -69,7 +69,7 @@ pub trait Content {
         E: Encoder,
     {
         if self.is_truthy() {
-            section.with(self).render(encoder)
+            section.render(encoder)
         } else {
             Ok(())
         }
@@ -87,7 +87,7 @@ pub trait Content {
         E: Encoder,
     {
         if !self.is_truthy() {
-            section.with(self).render(encoder)
+            section.render(encoder)
         } else {
             Ok(())
         }
@@ -458,6 +458,42 @@ where
         !self.is_empty()
     }
 
+    /// Render a section with self.
+    #[inline]
+    fn render_section<C, E>(
+        &self,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Render a section with self.
+    #[inline]
+    fn render_inverse<C, E>(
+        &self,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if !self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
+    }
+
     fn render_field_escaped<E>(&self, _: u64, name: &str, encoder: &mut E) -> Result<bool, E::Error>
     where
         E: Encoder,
@@ -525,6 +561,42 @@ where
 {
     fn is_truthy(&self) -> bool {
         !self.is_empty()
+    }
+
+    /// Render a section with self.
+    #[inline]
+    fn render_section<C, E>(
+        &self,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Render a section with self.
+    #[inline]
+    fn render_inverse<C, E>(
+        &self,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if !self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
     }
 
     fn render_field_escaped<E>(&self, _: u64, name: &str, encoder: &mut E) -> Result<bool, E::Error>

--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -476,24 +476,6 @@ where
         }
     }
 
-    /// Render a section with self.
-    #[inline]
-    fn render_inverse<C, E>(
-        &self,
-        section: Section<C>,
-        encoder: &mut E,
-    ) -> Result<(), E::Error>
-    where
-        C: ContentSequence,
-        E: Encoder,
-    {
-        if !self.is_truthy() {
-            section.with(self).render(encoder)
-        } else {
-            Ok(())
-        }
-    }
-
     fn render_field_escaped<E>(&self, _: u64, name: &str, encoder: &mut E) -> Result<bool, E::Error>
     where
         E: Encoder,
@@ -575,24 +557,6 @@ where
         E: Encoder,
     {
         if self.is_truthy() {
-            section.with(self).render(encoder)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Render a section with self.
-    #[inline]
-    fn render_inverse<C, E>(
-        &self,
-        section: Section<C>,
-        encoder: &mut E,
-    ) -> Result<(), E::Error>
-    where
-        C: ContentSequence,
-        E: Encoder,
-    {
-        if !self.is_truthy() {
             section.with(self).render(encoder)
         } else {
             Ok(())

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -10,7 +10,7 @@
 use super::{Block, Tag};
 use crate::encoding::Encoder;
 use crate::Content;
-use crate::traits::{ContentSequence};
+use crate::traits::{Combine, ContentSequence};
 use std::ops::Range;
 
 /// A section of a `Template` that can be rendered individually, usually delimited by
@@ -20,6 +20,10 @@ pub struct Section<'section, Contents: ContentSequence> {
     blocks: &'section [Block<'section>],
     contents: Contents,
 }
+
+/// Necessary so that the warning of very complex type created when compiling
+/// with `cargo clippy` doesn't propagate to downstream crates
+type Next<C, X> = (<C as Combine>::I, <C as Combine>::J, <C as Combine>::K, X);
 
 impl<'section> Section<'section, ()> {
     #[inline]
@@ -46,7 +50,7 @@ where
     /// Attach a `Content` to this section. This will keep track of a stack up to
     /// 4 `Content`s deep, cycling on overflow.
     #[inline]
-    pub fn with<X>(self, content: &X) -> Section<'section, (C::I, C::J, C::K, &X)>
+    pub fn with<X>(self, content: &X) -> Section<'section, Next<C, &X>>
     where
         X: Content + ?Sized,
     {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -463,8 +463,14 @@ fn can_render_self_referencing_structures() {
     let rendered = tpl.render(&Page {
         name: "Hello",
         subpages: &[
-            Page { name: "Foo", subpages: &[] },
-            Page { name: "Bar", subpages: &[] },
+            Page {
+                name: "Foo",
+                subpages: &[],
+            },
+            Page {
+                name: "Bar",
+                subpages: &[],
+            },
         ],
     });
 
@@ -488,12 +494,43 @@ fn can_render_fields_from_parents() {
 
     let rendered = tpl.render(&Father {
         father: "Bob",
-        son: Son {
-            name: "Charlie",
-        }
+        son: Son { name: "Charlie" },
     });
 
     assert_eq!(rendered, "Charlie's father is Bob.");
+}
+
+#[test]
+fn struct_with_many_types() {
+    #[derive(Content)]
+    struct Complicated<'a> {
+        name: &'a str,
+        size: u8,
+        position: i16,
+        tags: Vec<&'a str>,
+        nickname: Option<&'a str>,
+        children: &'a [Complicated<'a>],
+    }
+
+    let tpl = Template::new("This requires nothing but {{name}}.").unwrap();
+
+    let rendered = tpl.render(&Complicated {
+        name: "Name",
+        size: 1,
+        position: 2,
+        tags: vec!["tag1", "tag2"],
+        nickname: Some("nick"),
+        children: &[Complicated {
+            name: "Child",
+            size: 0,
+            position: 3,
+            tags: Vec::with_capacity(0),
+            nickname: None,
+            children: &[],
+        }],
+    });
+
+    assert_eq!(rendered, "This requires nothing but Name.");
 }
 
 #[test]


### PR DESCRIPTION
When deriving the `Content` trait for complicated structs ([like here](https://github.com/grego/ramhorns/commit/513648156fe1b532426ccca3c8d491cafa1d141e#diff-a2ee30bd60d759d336b7fa9ce8f57c12R503)), the compilation fails with the following error:
```
error: reached the recursion limit while instantiating `ramhorns::template::section::Section::<(&struct_with_many_types::Complicated, &i16, &struct_with_many_types::Complicated, &std::vec::Vec<&str>)>::render::<std::string::String>`
```
There are too many combinations of types to handle with the default recursion limit. (Even raising the recursion limit to as high as 2048 didn't solve the issue.) However, most of them, like `&str` or `u8`, have no chance of containing any fields, so adding them to the content sequence is not necessary. On the contrary, since the parent stack size is limited by design, they only prevent fields from the sections further up the tree to be used.
This PR fixes the issue by only adding to the content sequence the types that may actually contain some fields, i.e. `HashMap`, `BTreeMap` and derived structs. Even when for some simpler struct the trait managed to be derived without an error, the compilation time should be noticeably faster now.

Moreover, this PR fixes a minor warning (of too complex types used in the function signature) that would show when compiling the crate with `cargo clippy`. The warning would propagate to all downstream crates that'd use Ramhorns and be displayed whenever those crates would be compiled with clippy.