### PR TITLE
Tweaked partials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "beef"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,11 +427,13 @@ dependencies = [
 
 [[package]]
 name = "ramhorns"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
+ "beef 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ramhorns-derive 0.8.0",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,6 +502,11 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -605,7 +617,7 @@ dependencies = [
  "askama 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mustache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ramhorns 0.8.0",
+ "ramhorns 0.8.1",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -770,6 +782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum askama_shared 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee517f4e33c27b129928e71d8a044d54c513e72e0b72ec5c4f5f1823e9de353"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum beef 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aa1c724d818196ebb5a3725191ccc3e880aa7b6bec7c7291f02a8994e00f342d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
@@ -823,6 +836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
+"checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"

--- a/ramhorns/Cargo.toml
+++ b/ramhorns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramhorns"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Maciej Hirsz <maciej.hirsz@pm.me>"]
 license = "GPL-3.0"
 edition = "2018"
@@ -12,9 +12,11 @@ keywords = ["html", "template", "mustache"]
 categories = ["template-engine"]
 
 [dependencies]
+beef = "0.1.2"
 fnv = "1.0"
 pulldown-cmark = "0.7"
 ramhorns-derive = { version = "0.8.0", optional = true }
+rustc-hash = "1.1.0"
 
 [features]
 default = ["export_derive"]

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -10,8 +10,6 @@
 mod parse;
 mod section;
 
-use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fs::File;
 use std::hash::Hasher;
 use std::io;
@@ -20,6 +18,8 @@ use std::path::{Path, PathBuf};
 use crate::encoding::EscapingIOEncoder;
 use crate::{Content, Error};
 
+use rustc_hash::FxHashMap;
+use beef::Cow;
 use fnv::FnvHasher;
 
 pub use section::Section;
@@ -34,55 +34,50 @@ pub struct Template<'tpl> {
     capacity_hint: usize,
 
     /// Source from which this template was parsed.
-    source: Cow<'tpl, str>,
-
-    /// Partials used in this template
-    partials: Vec<Cow<'tpl, str>>,
+    source: Source<'tpl>,
 }
 
 /// A safe wrapper around a `HashMap` containing preprocessed templates
 /// of the type `Template`, accesible by their name
 pub struct Templates {
-    partials: HashMap<Cow<'static, str>, Template<'static>>,
+    partials: FxHashMap<Cow<'static, str>, Template<'static>>,
     dir: PathBuf,
 }
 
 impl<'tpl> Template<'tpl> {
     /// Create a new `Template` out of the source.
     ///
-    /// + If `Source` is a `&str`, this `Template` will borrow it with appropriate lifetime.
-    /// + If `Source` is a `String`, this `Template` will take it's ownership (The `'tpl` lifetime will be `'static`).
-    pub fn new<Source>(source: Source) -> Result<Self, Error>
+    /// + If `source` is a `&str`, this `Template` will borrow it with appropriate lifetime.
+    /// + If `source` is a `String`, this `Template` will take it's ownership (The `'tpl` lifetime will be `'static`).
+    pub fn new<S>(source: S) -> Result<Self, Error>
     where
-        Source: Into<Cow<'tpl, str>>,
+        S: Into<Cow<'tpl, str>>,
     {
         Template::load(source, &mut NoPartials)
     }
 
-    fn load<Source, T>(source: Source, partials: &mut T) -> Result<Self, Error>
+    fn load<S, T>(source: S, partials: &mut T) -> Result<Self, Error>
     where
-        Source: Into<Cow<'tpl, str>>,
+        S: Into<Cow<'tpl, str>>,
         T: Partials<'tpl>,
     {
-        let mut tpl = Template {
-            blocks: Vec::new(),
-            capacity_hint: 0,
-            source: source.into(),
-            partials: Vec::with_capacity(0),
-        };
+        let source = source.into();
 
         // This is allows `Block`s inside this `Template` to be references of the `source` field.
         // This is safe as long as the `source` field is never mutated or moved.
-        let source: &'tpl str = unsafe {
-            use std::{slice, str};
+        let unsafe_source: &'tpl str = unsafe {
+            use std::borrow::Borrow;
 
-            let ptr = tpl.source.as_ptr();
-            let len = tpl.source.len();
-
-            str::from_utf8_unchecked(slice::from_raw_parts(ptr, len))
+            &*(source.borrow() as *const str)
         };
 
-        let mut iter = source
+        let mut tpl = Template {
+            blocks: Vec::new(),
+            capacity_hint: 0,
+            source: Source::One(source),
+        };
+
+        let mut iter = unsafe_source
             .as_bytes()
             .windows(2)
             .map(|b| unsafe { &*(b.as_ptr() as *const [u8; 2]) }) // windows iterator makes this safe
@@ -90,8 +85,8 @@ impl<'tpl> Template<'tpl> {
 
         let mut last = 0;
 
-        tpl.parse(source, &mut iter, &mut last, None, partials)?;
-        let tail = &source[last..].trim_end();
+        tpl.parse(unsafe_source, &mut iter, &mut last, None, partials)?;
+        let tail = &unsafe_source[last..].trim_end();
         tpl.blocks.push(Block::new(tail, "", Tag::Tail));
         tpl.capacity_hint += tail.len();
 
@@ -144,7 +139,10 @@ impl<'tpl> Template<'tpl> {
 
     /// Get a reference to a source this `Template` was created from.
     pub fn source(&self) -> &str {
-        &self.source
+        match self.source {
+            Source::One(ref source) => source,
+            Source::Many(ref sources) => &sources[0],
+        }
     }
 }
 
@@ -156,14 +154,21 @@ impl Template<'static> {
     /// let tpl = Template::from_file("./templates/my_template.html").unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let mut partials = Templates::new(
+        let mut tpls = Templates::new(
             path.as_ref()
                 .parent()
                 .unwrap_or_else(|| ".".as_ref())
                 .canonicalize()?,
         );
-        Template::load(std::fs::read_to_string(&path)?, &mut partials).map(move |mut tpl| {
-            tpl.partials = partials.into_sources();
+        Template::load(std::fs::read_to_string(&path)?, &mut tpls).map(move |mut tpl| {
+            tpl.source = tpl.source.extend(
+                tpls.partials
+                    .into_iter()
+                    .map(|(_, tpl)| match tpl.source {
+                        Source::One(source) => source,
+                        Source::Many(_) => unreachable!(),
+                    }),
+            );
             tpl
         })
     }
@@ -172,7 +177,7 @@ impl Template<'static> {
 impl Templates {
     fn new(dir: PathBuf) -> Self {
         Templates {
-            partials: HashMap::new(),
+            partials: FxHashMap::default(),
             dir,
         }
     }
@@ -198,7 +203,8 @@ impl Templates {
                         .strip_prefix(&templates.dir)
                         .unwrap_or(&path)
                         .to_string_lossy();
-                    if !templates.partials.contains_key(&name) {
+
+                    if !templates.partials.contains_key(&*name) {
                         let template = Template::load(std::fs::read_to_string(&path)?, templates)?;
                         templates
                             .partials
@@ -222,6 +228,36 @@ impl Templates {
         self.partials.get(name)
     }
 }
+
+enum Source<'tpl> {
+    /// Template is constructed from a single source
+    One(Cow<'tpl, str>),
+
+    /// Template is constructed from multiple sources
+    Many(Vec<Cow<'tpl, str>>),
+}
+
+impl<'tpl> Source<'tpl> {
+    fn extend<T>(self, iter: T) -> Self
+    where
+        T: IntoIterator<Item = Cow<'tpl, str>>,
+    {
+        Source::Many(match self {
+            Source::One(source) => {
+                let iter = iter.into_iter();
+                let mut sources = Vec::with_capacity(1 + iter.size_hint().0);
+                sources.push(source);
+                sources.extend(iter);
+                sources
+            },
+            Source::Many(mut sources) => {
+                sources.extend(iter);
+                sources
+            },
+        })
+    }
+}
+
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tag {
@@ -277,7 +313,6 @@ impl<'tpl> Block<'tpl> {
 
 pub(crate) trait Partials<'tpl> {
     fn get_partial(&mut self, name: &'tpl str) -> Result<&Template<'tpl>, Error>;
-    fn into_sources(self) -> Vec<Cow<'tpl, str>>;
 }
 
 struct NoPartials;
@@ -285,10 +320,6 @@ struct NoPartials;
 impl<'tpl> Partials<'tpl> for NoPartials {
     fn get_partial(&mut self, _name: &'tpl str) -> Result<&Template<'tpl>, Error> {
         Err(Error::PartialsDisabled)
-    }
-
-    fn into_sources(self) -> Vec<Cow<'tpl, str>> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -303,13 +334,6 @@ impl Partials<'static> for Templates {
             self.partials.insert(name.into(), template);
         };
         Ok(&self.partials[name])
-    }
-
-    fn into_sources(self) -> Vec<Cow<'static, str>> {
-        self.partials
-            .into_iter()
-            .map(|(_, tpl)| tpl.source)
-            .collect()
     }
 }
 

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -324,11 +324,11 @@ impl<'tpl> Partials<'tpl> for NoPartials {
 
 impl Partials<'static> for Templates {
     fn get_partial(&mut self, name: &'static str) -> Result<&Template<'static>, Error> {
-        let path = self.dir.join(name).canonicalize()?;
-        if !path.starts_with(&self.dir) {
-            return Err(Error::IllegalPartial(name.into()));
-        }
         if !self.partials.contains_key(name) {
+            let path = self.dir.join(name).canonicalize()?;
+            if !path.starts_with(&self.dir) {
+                return Err(Error::IllegalPartial(name.into()));
+            }
             let template = Template::load(std::fs::read_to_string(&path)?, self)?;
             self.partials.insert(name.into(), template);
         };

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -240,11 +240,10 @@ enum Source<'tpl> {
 impl<'tpl> Source<'tpl> {
     fn extend<T>(self, iter: T) -> Self
     where
-        T: IntoIterator<Item = Cow<'tpl, str>>,
+        T: Iterator<Item = Cow<'tpl, str>>,
     {
         Source::Many(match self {
             Source::One(source) => {
-                let iter = iter.into_iter();
                 let mut sources = Vec::with_capacity(1 + iter.size_hint().0);
                 sources.push(source);
                 sources.extend(iter);

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -64,11 +64,9 @@ impl<'tpl> Template<'tpl> {
         let source = source.into();
 
         // This is allows `Block`s inside this `Template` to be references of the `source` field.
-        // This is safe as long as the `source` field is never mutated or moved.
+        // This is safe as long as the `source` field is never mutated or dropped.
         let unsafe_source: &'tpl str = unsafe {
-            use std::borrow::Borrow;
-
-            &*(source.borrow() as *const str)
+            &*(&*source as *const str)
         };
 
         let mut tpl = Template {


### PR DESCRIPTION
+ Removed `partials` from `Template`, instead `source` is now an enum that allows either a single source, or a `Vec` with multiple sources.
+ Replaced `std::borrow::Cow` with [`beef::Cow`](https://github.com/maciejhirsz/beef/), this is mostly a drop-in replacement that reduces size by 1 word. Combined with above change `Template` is now 8 words long, down from 11.
+ Using `rustc_hash` as a hasher for the `HashMap` in `Templates` for a bit more of a perf boost.

@grego what do you think about removing `Template::from_file` entirely? It would reduce the size of `Template` by another word (enum tag on `source`), reduce code complexity, and force users into avoiding an anti-pattern of duplicating partials in memory.