### PR TITLE
Add derive attributes for renaming or skipping a field

### DIFF
--- a/ramhorns-derive/src/lib.rs
+++ b/ramhorns-derive/src/lib.rs
@@ -18,26 +18,29 @@
 
 extern crate proc_macro;
 
-use quote::quote;
+use fnv::FnvHasher;
 use proc_macro::TokenStream;
-use syn::{ItemStruct, Field, Fields};
+use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use fnv::FnvHasher;
+use syn::{Attribute, Error, Field, Fields, ItemStruct};
 
 use std::hash::Hasher;
 
 type UnitFields = Punctuated<Field, Comma>;
 
-#[proc_macro_derive(Content, attributes(md))]
+#[proc_macro_derive(Content, attributes(md, ramhorns))]
 pub fn content_derive(input: TokenStream) -> TokenStream {
-    let item: ItemStruct = syn::parse(input).expect("#[derive(Content)] can be only applied to structs");
+    let item: ItemStruct =
+        syn::parse(input).expect("#[derive(Content)] can be only applied to structs");
 
     // panic!("{:#?}", item);
 
     let name = &item.ident;
     let generics = &item.generics;
     let unit_fields = UnitFields::new();
+
+    let mut errors = Vec::new();
 
     let fields = match &item.fields {
         Fields::Named(fields) => fields.named.iter(),
@@ -47,32 +50,83 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
 
     let mut fields = fields
         .enumerate()
-        .map(|(index, field)| {
-            let iter = field.attrs
-                .iter()
-                .filter_map(|attr| attr.path.segments.first())
-                .map(|pair| &pair.ident);
-
+        .flat_map(|(index, field)| {
             let mut method = None;
+            let mut rename = None;
+            let mut skip = false;
 
-            for attr in iter {
-                if attr == "md" {
+            let mut parse_attr = |attr: &Attribute| -> Result<(), Error> {
+                use syn::{Lit, Meta, NestedMeta, spanned::Spanned};
+
+                if attr.path.is_ident("md") {
                     method = Some(quote!(render_cmark));
+                } else if attr.path.is_ident("ramhorns") {
+                    if let Meta::List(meta_list) = attr.parse_meta()? {
+                        for nested_meta in &meta_list.nested {
+                            if let NestedMeta::Meta(meta) = nested_meta {
+                                match meta {
+                                    Meta::Path(path) if path.is_ident("skip") => {
+                                        skip = true;
+                                    }
+                                    Meta::NameValue(nv) if nv.path.is_ident("rename") => {
+                                        if let Lit::Str(ref lit_str) = nv.lit {
+                                            rename = Some(lit_str.value())
+                                        } else {
+                                            return Err(Error::new(
+                                                nv.span(),
+                                                "fields can only be renamed to string literals",
+                                            ));
+                                        }
+                                    }
+                                    _ => {
+                                        return Err(Error::new(
+                                            meta.span(),
+                                            "no such attribute in `ramhorns`",
+                                        ));
+                                    }
+                                }
+                            } else {
+                                return Err(Error::new(
+                                    nested_meta.span(),
+                                    "literals have no meaning in `ramhorns` attributes; did you mean `rename = \"literal\"`?"
+                                ));
+                            }
+                        }
+                    } else {
+                        return Err(Error::new(
+                            attr.span(),
+                            "missing attributes; did you mean `#[ramhorns(rename = \"literal\")]`?"
+                        ));
+                    }
                 }
+                Ok(())
+            };
+
+            errors.extend(field.attrs.iter().flat_map(|attr| parse_attr(attr).err()));
+
+            if skip {
+                return None;
             }
 
-            let (name, token) = field.ident
-                .as_ref()
-                .map(|ident| (ident.to_string(), quote!(#ident)))
-                .unwrap_or_else(|| {
-                    use syn::{LitInt};
+            let (name, token) = field.ident.as_ref().map_or_else(
+                || {
                     use proc_macro2::Span;
+                    use syn::LitInt;
 
                     let index = index.to_string();
                     let lit = LitInt::new(&index, Span::call_site());
+                    let name = rename.as_ref().cloned().unwrap_or(index);
 
-                    (index, quote!(#lit))
-                });
+                    (name, quote!(#lit))
+                },
+                |ident| {
+                    let name = rename
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| ident.to_string());
+                    (name, quote!(#ident))
+                },
+            );
 
             let mut hasher = FnvHasher::default();
 
@@ -80,11 +134,21 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
 
             let hash = hasher.finish();
 
-            (name, token, hash, method)
+            Some((name, token, hash, method))
         })
         .collect::<Vec<_>>();
 
-    fields.sort_unstable_by(|a, b| (a.2).cmp(&b.2));
+    if !errors.is_empty() {
+        let errors: Vec<_> = errors.into_iter().map(|e| e.to_compile_error()).collect();
+        return quote! {
+            fn _ramhorns_derive_compile_errors() {
+                #(#errors)*
+            }
+        }
+        .into();
+    }
+
+    fields.sort_unstable_by_key(|&(_, _, hash, _)| hash);
 
     let render_escaped = quote!(render_escaped);
     let render_field_escaped = fields.iter().map(|(_, field, hash, method)| {
@@ -125,7 +189,7 @@ pub fn content_derive(input: TokenStream) -> TokenStream {
             fn capacity_hint(&self, tpl: &ramhorns::Template) -> usize {
                 tpl.capacity_hint() #( + self.#fields.capacity_hint(tpl) )*
             }
-            
+
             #[inline]
             fn render_section<C, E>(&self, section: ramhorns::Section<C>, encoder: &mut E) -> Result<(), E::Error>
             where

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -1,4 +1,4 @@
-use ramhorns::{Content, Template, Ramhorns};
+use ramhorns::{Content, Ramhorns, Template};
 
 #[derive(Content)]
 struct Post<'a> {
@@ -531,6 +531,26 @@ fn struct_with_many_types() {
     });
 
     assert_eq!(rendered, "This requires nothing but Name.");
+}
+
+#[test]
+fn derive_attributes() {
+    #[derive(Content)]
+    struct Post<'a> {
+        #[ramhorns(skip)]
+        _title: &'a str,
+        #[ramhorns(rename = "head")]
+        body: &'a str,
+    }
+
+    let tpl = Template::new("<h1>{{_title}}</h1><head>{{head}}</head>").unwrap();
+
+    let html = tpl.render(&Post {
+        _title: "This is the title",
+        body: "This is actually head!",
+    });
+
+    assert_eq!(html, "<h1></h1><head>This is actually head!</head>");
 }
 
 #[test]


### PR DESCRIPTION
Sometimes it's desirable to use a field in a template with a different name, or for safety or other reasons to not allow using the field to render add all.
This PR adds derive attributes in style of [serde field attributes](https://serde.rs/field-attrs.html) for skipping or renaming a field in a struct.
The attributes can be used on fields as follows:
```rust
#[derive(Content)]
struct Data<'a> {
    #[ramhorns(skip)]
    secret: &'a str,
    #[ramhorns(rename = "new")]
    old: &'a str,
}
```

