### PR TITLE
Reduce number of content sequences to speed up compile time

### DIFF
--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -49,7 +49,7 @@ impl<'tpl> Template<'tpl> {
         Template::load(source, &mut NoPartials)
     }
 
-    pub(crate) fn load<S>(source: S, partials: &mut dyn Partials<'tpl>) -> Result<Self, Error>
+    pub(crate) fn load<S>(source: S, partials: &mut impl Partials<'tpl>) -> Result<Self, Error>
     where
         S: Into<Cow<'tpl, str>>,
     {
@@ -112,7 +112,7 @@ impl<'tpl> Template<'tpl> {
         C: Content,
     {
         use io::BufWriter;
-
+        
         let writer = BufWriter::new(File::create(path)?);
         let mut encoder = EscapingIOEncoder::new(writer);
 

--- a/ramhorns/src/template/parse.rs
+++ b/ramhorns/src/template/parse.rs
@@ -70,7 +70,7 @@ impl<'tpl> Template<'tpl> {
     pub(crate) fn parse(
         &mut self,
         source: &'tpl str,
-        partials: &mut dyn Partials<'tpl>,
+        partials: &mut impl Partials<'tpl>,
     ) -> Result<usize, Error> {
         let mut last = 0;
         let mut lex = Opening::lexer(source);

--- a/ramhorns/src/template/section.rs
+++ b/ramhorns/src/template/section.rs
@@ -60,6 +60,16 @@ where
         }
     }
 
+    /// The section without the last `Content` in the stack
+    #[inline]
+    pub fn without_last(self) -> Section<'section, C::Previous>
+    {
+        Section {
+            blocks: self.blocks,
+            contents: self.contents.crawl_back(),
+        }
+    }
+
     /// Render this section once to the provided `Encoder`.
     pub fn render<E>(&self, encoder: &mut E) -> Result<(), E::Error>
     where

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -534,6 +534,39 @@ fn struct_with_many_types() {
 }
 
 #[test]
+fn struct_with_many_sections() {
+    #[derive(Content)]
+    struct A(u8);
+    #[derive(Content)]
+    struct B(f64);
+    #[derive(Content)]
+    struct C(&'static str);
+    #[derive(Content)]
+    struct D(bool);
+
+    #[derive(Content)]
+    struct Page {
+        a: A,
+        b: B,
+        c: C,
+        d: D,
+        other: &'static [Page],
+    }
+
+    let tpl = Template::new("<h1>{{#d}}{{#0}}{{#c}}{{0}}{{/c}}{{/0}}{{/d}} world!</h1>").unwrap();
+    
+    let rendered = tpl.render(&Page {
+        a: A(1),
+        b: B(2.0),
+        c: C("Hello"),
+        d: D(true),
+        other: &[]
+    });
+
+    assert_eq!(rendered, "<h1>Hello world!</h1>");
+}
+
+#[test]
 fn derive_attributes() {
     #[derive(Content)]
     struct Post<'a> {


### PR DESCRIPTION
Consider the test example:
```rust
    #[derive(Content)]
    struct A {
        ain: u8,
    };
    #[derive(Content)]
    struct B {
        bin1: f64,
        bin2: f64,
    };
    #[derive(Content)]
    struct C(&'static str);
    #[derive(Content)]
    struct D(bool);

    #[derive(Content)]
    struct Page {
        a: A,
        b: B,
        c: C,
        d: D,
        other: &'static [Page],
    }
```
In order for it to compile, the recursion limit needs to be raised to `369` and then, it takes roughly `25s` to compile on my machine. That's because the compiler needs to "prepare" for every possible sequence of contents. However, most of them are very unlikely to occur.

This PR reduces these by "crawling back" in the content tree when the section is not found in the current content. Effectively, the current content is forgotten and not used in the further content sequences. In other words, the sections in the content sequence always lie on a path in the content tree. All of the previous contents are the ancestors of the current one. This decreases the number of possible content sequences from quartic (the length of the content sequence is 4) to linear, eradicates the need to raise the recursion limit and the compilation is significantly faster: roughly `2.5s` on my machine.

The [mustache specification](https://mustache.github.io/mustache.5.html) does not mention using sections from the parent contexts at all, so this is kind of an extra feature anyway. All tests are passed and in the majority of cases, the behaviour remains the same. Then, there are some edge differences. Consider the structs from the example.

`{{#a}} {{#b}} {{bin1}} + {{ain}} + {{bin2}} {{/b}} {{/a}}` 
now doesn't render `{{ain}}`, as it's not found in `b`, nor in any of the parent contents in the content tree. We can always return to the previous behaviour by using  
`{{#a}} {{#b}} {{bin1}} + {{#a}} {{ain}} {{/a}} + {{bin2}} {{/b}} {{/a}}`. 
This is quite verbose, on the other hand it makes clear in which content the variable is expected.
However, mostly a much simpler solution would suffice: 
`{{#a}} {{#b}} {{bin1}} {{/b}} + {{ain}} + {{#b}} {{bin2}} {{/b}} {{/a}}`, 
or even
`{{#b}} {{bin1}} + {{#a}} {{ain}} {{/a}} + {{bin2}} {{/b}}`.

The only case where a workaround of this sort is not possible is when `a` and `b` are both lists, but my imagination is not sufficient to conceive an actual example of where a construct like that would be desired. I don't think it's required by the specification, as the sections form parent contexts are not mentioned there, and speeding the compilation up, as well as reducing the binary size provides more practical advantages.