### PR TITLE
Do not render section when its name is not found in any context

### DIFF
--- a/ramhorns/src/traits.rs
+++ b/ramhorns/src/traits.rs
@@ -195,10 +195,7 @@ where
                 let section = section.without_last();
                 if !self.1.render_field_section(hash, name, section, encoder)? {
                     let section = section.without_last();
-                    if !self.0.render_field_section(hash, name, section, encoder)? {
-                        let section = section.without_last();
-                        section.render(encoder)?;
-                    }
+                    self.0.render_field_section(hash, name, section, encoder)?;
                 }
             }
         }

--- a/ramhorns/src/traits.rs
+++ b/ramhorns/src/traits.rs
@@ -221,7 +221,6 @@ where
                 if !self.1.render_field_inverse(hash, name, section, encoder)? {
                     let section = section.without_last();
                     if !self.0.render_field_inverse(hash, name, section, encoder)? {
-                        let section = section.without_last();
                         section.render(encoder)?;
                     }
                 }


### PR DESCRIPTION
Per mustache specification, when the name of a variable is not found in any context, it is not rendered.
This PR makes this behaviour consistent for sections.

Note the same is not done for inverses. Personally, I think as far as it is possible, the desired behaviour should be to always have exactly one of section or its inverse rendered.