### PR TITLE
Don't removing content when rendering inverses

### DIFF
--- a/ramhorns/src/traits.rs
+++ b/ramhorns/src/traits.rs
@@ -215,11 +215,8 @@ where
         E: Encoder,
     {
         if !self.3.render_field_inverse(hash, name, section, encoder)? {
-            let section = section.without_last();
             if !self.2.render_field_inverse(hash, name, section, encoder)? {
-                let section = section.without_last();
                 if !self.1.render_field_inverse(hash, name, section, encoder)? {
-                    let section = section.without_last();
                     if !self.0.render_field_inverse(hash, name, section, encoder)? {
                         section.render(encoder)?;
                     }


### PR DESCRIPTION
I seem to have forgotten in my previous PR how `ContentSequence` works. The content is added to the right and the most common state is `((), (), (), Content)`.
Therefore, when rendering an inverse that's not located in any content, it should not be desired to crawl up the content tree, since one may want to use other variables inside the inverse block.

Another option would be to keep a copy of the old `ContentSequence` and use it if the given field was not found anywhere, but that seems more cumbersome to me.