### PR TITLE
Add basic handling for generics in derive macro

### DIFF
--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -382,6 +382,42 @@ fn can_render_lists_from_vecs() {
 }
 
 #[test]
+fn can_render_generic_types() {
+    #[derive(Content)]
+    struct Article {
+        title: String,
+        body: String,
+    }
+
+    #[derive(Content)]
+    struct Page<T> {
+        #[ramhorns(flatten)]
+        contents: T,
+        last_updated: String,
+    }
+
+    let tpl = Template::new(
+        "<h1>{{title}}</h1>\
+         <article>{{body}}</article>\
+         <p>{{last_updated}}</p>",
+    )
+    .unwrap();
+
+    let html = tpl.render(&Page {
+        last_updated: "yesterday".into(),
+        contents: Article {
+            title: "Jam".into(),
+            body: "This is an article body".into(),
+        },
+    });
+
+    assert_eq!(
+        html,
+        "<h1>Jam</h1><article>This is an article body</article><p>yesterday</p>"
+    )
+}
+
+#[test]
 fn can_render_markdown() {
     #[derive(Content)]
     struct Post<'a> {
@@ -554,13 +590,13 @@ fn struct_with_many_sections() {
     }
 
     let tpl = Template::new("<h1>{{#d}}{{#0}}{{#c}}{{0}}{{/c}}{{/0}}{{/d}} world!</h1>").unwrap();
-    
+
     let rendered = tpl.render(&Page {
         a: A(1),
         b: B(2.0),
         c: C("Hello"),
         d: D(true),
-        other: &[]
+        other: &[],
     });
 
     assert_eq!(rendered, "<h1>Hello world!</h1>");
@@ -606,10 +642,13 @@ fn derive_flatten() {
         title: "This is the title",
         child: Child {
             body: "This is the body",
-        }
+        },
     });
 
-    assert_eq!(html, "<h1>This is the title</h1><head>This is the body</head>");
+    assert_eq!(
+        html,
+        "<h1>This is the title</h1><head>This is the body</head>"
+    );
 }
 
 #[test]

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -382,7 +382,45 @@ fn can_render_lists_from_vecs() {
 }
 
 #[test]
-fn can_render_generic_types() {
+fn can_render_nested_generic_types() {
+    #[derive(Content)]
+    struct Article {
+        title: String,
+        body: String,
+    }
+
+    #[derive(Content)]
+    struct Page<T> {
+        contents: T,
+        last_updated: String,
+    }
+
+    let tpl = Template::new(
+        "\
+        {{#contents}}\
+        <h1>{{title}}</h1>\
+        <article>{{body}}</article>\
+        {{/contents}}\
+        <p>{{last_updated}}</p>",
+    )
+    .unwrap();
+
+    let html = tpl.render(&Page {
+        last_updated: "yesterday".into(),
+        contents: Article {
+            title: "Jam".into(),
+            body: "This is an article body".into(),
+        },
+    });
+
+    assert_eq!(
+        html,
+        "<h1>Jam</h1><article>This is an article body</article><p>yesterday</p>"
+    )
+}
+
+#[test]
+fn can_render_flattened_generic_types() {
     #[derive(Content)]
     struct Article {
         title: String,


### PR DESCRIPTION
This is pretty simple, I've tried to do the bare minimum to get things working, rather than make things too complex, but it solves my initial use-case, and making future changes with generics should be a simple additive process when new use-cases are found.

We basically pull the type params out of the generics object (i.e. not the lifetimes, and not any const parameters either), and, if there are any, create a `where`-clause of `T: ::ramhorns::Content` for each type param (i.e. `T`) that has been declared.

There are probably improvements that could be made, such as not adding the type bound if the `ramhorns(skip)` attribute is used for that field, or copying over other type bounds that exist, but I figure they can be added later if they are likely to actually be useful to someone.

Closes #38 