### PR TITLE
Store the name of the partial that was not found

### DIFF
--- a/ramhorns/src/error.rs
+++ b/ramhorns/src/error.rs
@@ -7,7 +7,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Ramhorns.  If not, see <http://www.gnu.org/licenses/>
 
-use std::{fmt, io, error};
+use std::{error, fmt, io};
 
 /// Error type used that can be emitted during template parsing.
 #[derive(Debug)]
@@ -34,6 +34,9 @@ pub enum Error {
 
     /// Attempted to load a partial outside of the templates folder
     IllegalPartial(Box<str>),
+
+    /// The template file with the given name was not found
+    NotFound(Box<str>),
 }
 
 impl error::Error for Error {}
@@ -63,11 +66,9 @@ impl fmt::Display for Error {
                 "Section not closed properly, was expecting {{{{/{}}}}}",
                 name
             ),
-            Error::UnopenedSection(name) => write!(
-                f,
-                "Unexpected closing section {{{{/{}}}}}",
-                name
-            ),
+            Error::UnopenedSection(name) => {
+                write!(f, "Unexpected closing section {{{{/{}}}}}", name)
+            }
             Error::UnclosedTag => write!(f, "Couldn't find closing braces matching opening braces"),
             Error::PartialsDisabled => write!(f, "Partials are not allowed in the current context"),
             Error::IllegalPartial(name) => write!(
@@ -75,6 +76,7 @@ impl fmt::Display for Error {
                 "Attempted to load {}; partials can only be loaded from the template directory",
                 name
             ),
+            Error::NotFound(name) => write!(f, "Template file {} not found", name),
         }
     }
 }


### PR DESCRIPTION
`std::io::Error` does not preserve the name of the file that was not found. This PR adds a new `Error` enum variant `NotFound`, so that this piece of information remains available when a partial is not found.