### PR TITLE
Add the ability to extend the template collection from another folder

### DIFF
--- a/tests/more_templates/basic2.html
+++ b/tests/more_templates/basic2.html
@@ -1,0 +1,5 @@
+{{>head.html}}
+<body>
+    <div>More {{body}}</div>
+    {{>footer.html}}
+</body>

--- a/tests/more_templates/basic2.result
+++ b/tests/more_templates/basic2.result
@@ -1,0 +1,7 @@
+<head>
+    <title>Hello, Ramhorns!</title>
+</head>
+<body>
+    <div>More This is a really simple test of the rendering!</div>
+    <footer>Sup?</footer>
+</body>

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -721,6 +721,23 @@ fn simple_partials_folder() {
 }
 
 #[test]
+fn simple_partials_extend() {
+    use std::fs::read_to_string;
+
+    let mut tpls = Ramhorns::from_folder("templates").unwrap();
+    tpls.extend_from_folder("more_templates").unwrap();
+    let post = Post {
+        title: "Hello, Ramhorns!",
+        body: "This is a really simple test of the rendering!",
+    };
+
+    assert_eq!(
+        tpls.get("basic2.html").unwrap().render(&post),
+        read_to_string("more_templates/basic2.result").unwrap().trim_end()
+    );
+}
+
+#[test]
 fn illegal_partials() {
     use ramhorns::Error;
 


### PR DESCRIPTION
Adds functions `extend_from_folder` and `extend_from_folder_with_extension` to include templates from another folder in the collection.
If there is a file with the same name as a previously loaded template or partial, it will not be loaded.
Also, this should fix the issue maciejhirsz#53 (the name of the partial which was not found should always be returned).