### PR TITLE
Derive `Debug` for `Ramhorns` & `Template`.

### DIFF
--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -101,6 +101,7 @@ pub use ramhorns_derive::Content;
 ///
 /// For faster or DOS-resistant hashes, it is recommended to use
 /// [aHash](https://docs.rs/ahash/latest/ahash/) `RandomState` as hasher.
+#[derive(Debug)]
 pub struct Ramhorns<H = fnv::FnvBuildHasher> {
     partials: HashMap<Cow<'static, str>, Template<'static>, H>,
     dir: PathBuf,

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -27,6 +27,7 @@ pub use parse::Tag;
 
 /// A preprocessed form of the plain text template, ready to be rendered
 /// with data contained in types implementing the `Content` trait.
+#[derive(Debug)]
 pub struct Template<'tpl> {
     /// Parsed blocks!
     blocks: Vec<Block<'tpl>>,


### PR DESCRIPTION
# Problem

`Debug`, a widely-used trait, isn't implemented for the structs `Ramhorns` and `Template`. As a result, users of the crate who'd like to store them inside a struct that does derive it are forced to create wrapper structs and manually implement the trait.

# Solution

Annotate `Ramhorns` and `Template` with `#[derive(Debug)]`.