### PR TITLE
Add a method to manually insert a template parsed from source

### DIFF
--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -224,15 +224,28 @@ impl<H: BuildHasher + Default> Ramhorns<H> {
     // Unsafe to expose as it loads the template from arbitrary path.
     #[inline]
     fn load_internal(&mut self, path: &Path, name: Cow<'static, str>) -> Result<(), Error> {
-        let file = match std::fs::read_to_string(&path) {
+        let file = match std::fs::read_to_string(path) {
             Ok(file) => Ok(file),
             Err(e) if e.kind() == ErrorKind::NotFound => {
                 Err(Error::NotFound(name.to_string().into()))
             }
             Err(e) => Err(Error::Io(e)),
         }?;
-        let template = Template::load(file, self)?;
-        self.partials.insert(name, template);
+        self.insert(file, name)
+    }
+
+    /// Insert a template parsed from `src` with the name `name`.
+    /// If a template with this name is present, it gets replaced.
+    ///
+    /// # Warning
+    /// This can load partials from an arbitrary path. Use only with trusted source.
+    pub fn insert<S, T>(&mut self, src: S, name: T) -> Result<(), Error>
+    where
+        S: Into<Cow<'static, str>>,
+        T: Into<Cow<'static, str>>
+    {
+        let template = Template::load(src, self)?;
+        self.partials.insert(name.into(), template);
         Ok(())
     }
 }

--- a/tests/templates/style.css
+++ b/tests/templates/style.css
@@ -1,0 +1,1 @@
+html { display: none; }

--- a/tests/templates/style.result
+++ b/tests/templates/style.result
@@ -1,0 +1,1 @@
+html { display: none; } OH YEAH

--- a/tests/templates/yeah.result
+++ b/tests/templates/yeah.result
@@ -1,0 +1,3 @@
+<head>
+    <title>Hello, Ramhorns!</title>
+</head> OH YEAH

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -747,6 +747,30 @@ fn simple_partials_folder() {
 }
 
 #[test]
+fn simple_partials_insert() {
+    use std::fs::read_to_string;
+
+    let mut tpls: Ramhorns = Ramhorns::from_folder("templates").unwrap();
+    let post = Post {
+        title: "Hello, Ramhorns!",
+        body: "This is a really simple test of the rendering!",
+    };
+
+    tpls.insert("{{>head.html}} OH YEAH", "yeah.html").unwrap();
+    assert_eq!(
+        tpls.get("yeah.html").unwrap().render(&post),
+        read_to_string("templates/yeah.result").unwrap().trim_end()
+    );
+    tpls.insert("{{>style.css}} OH YEAH", "style.html").unwrap();
+    assert_eq!(
+        tpls.get("style.html").unwrap().render(&post),
+        read_to_string("templates/style.result")
+            .unwrap()
+            .trim_end()
+    );
+}
+
+#[test]
 fn simple_partials_extend() {
     use std::fs::read_to_string;
 


### PR DESCRIPTION
This covers the cases where the source is available elsewhere than in a particular file