### PR TITLE
Enable running in WebAssembly

### DIFF
--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -120,15 +120,15 @@ impl<H: BuildHasher + Default> Ramhorns<H> {
     /// let data = Data{
     ///     content: "I am the content".to_string(),
     /// };
-    /// let mut tpls: Ramhorns = Ramhorns::new().unwrap();
+    /// let mut tpls: Ramhorns = Ramhorns::new();
     /// tpls.insert("{{content}}", "template").unwrap();
     /// let rendered = tpls.get("template").unwrap().render(&data);
     /// ```
-    pub fn new() -> Result<Self, Error> {
-        Ok(Ramhorns {
+    pub fn new() -> Self {
+        Ramhorns {
             partials: HashMap::default(),
             dir: PathBuf::new(),
-        })
+        }
     }
 
     /// Loads all the `.html` files as templates from the given folder, making them

--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -109,6 +109,14 @@ impl<H> fmt::Debug for Ramhorns<H> {
 }
 
 impl<H: BuildHasher + Default> Ramhorns<H> {
+
+    pub fn new() -> Result<Self, Error> {
+        Ok(Ramhorns {
+            partials: HashMap::default(),
+            dir: PathBuf::new(),
+        })
+    }
+
     /// Loads all the `.html` files as templates from the given folder, making them
     /// accessible via their path, joining partials as required. If a custom
     /// extension is wanted, see [from_folder_with_extension]
@@ -200,7 +208,7 @@ impl<H: BuildHasher + Default> Ramhorns<H> {
             partials: HashMap::default(),
             dir: dir.as_ref().canonicalize()?,
         })
-    }
+    } 
 
     /// Get the template with the given name, if it exists.
     pub fn get(&self, name: &str) -> Option<&Template<'static>> {

--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -110,6 +110,20 @@ impl<H> fmt::Debug for Ramhorns<H> {
 
 impl<H: BuildHasher + Default> Ramhorns<H> {
 
+    /// Create a new empty aggregator with no initial folder.
+    /// ```no_run
+    /// use ramhorns::{Ramhorns,Content};
+    /// #[derive(Content)]
+    /// struct Data {
+    ///     content: String,
+    /// }
+    /// let data = Data{
+    ///     content: "I am the content".to_string(),
+    /// };
+    /// let mut tpls: Ramhorns = Ramhorns::new().unwrap();
+    /// tpls.insert("{{content}}", "template").unwrap();
+    /// let rendered = tpls.get("template").unwrap().render(&data);
+    /// ```
     pub fn new() -> Result<Self, Error> {
         Ok(Ramhorns {
             partials: HashMap::default(),


### PR DESCRIPTION
This is not ready for merge. Currently it's just a quick hack to solve my problem. I'm running Ramhorns in WebAssembly with no filesystem access. All of the current static methods do some sort of filesystem access (even `Ramhorns::lazy`), which crashes.

This PR implements a `Ramhorns::new` static method that takes no parameters and doesn't access the filesystem. Templates must be added manually with `Ramhorns.insert()`.

If there's interest in having this merged I'm happy to flesh it out with docs and tests, but I wanted to check first.