### PR TITLE
fix: Expose Index & Indexed

### DIFF
--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -89,6 +89,9 @@ pub use content::Content;
 pub use error::Error;
 pub use template::{Section, Template};
 
+#[cfg(feature = "indexes")]
+pub use template::{Index, Indexed};
+
 #[cfg(feature = "export_derive")]
 pub use ramhorns_derive::Content;
 

--- a/ramhorns/src/template/mod.rs
+++ b/ramhorns/src/template/mod.rs
@@ -21,7 +21,7 @@ mod section;
 #[cfg(not(feature = "indexes"))]
 pub use parse::Tag;
 #[cfg(feature = "indexes")]
-pub use parse::{Index::Last, Indexed, Tag};
+pub use parse::{Index, Indexed, Tag};
 pub use section::Section;
 
 /// A preprocessed form of the plain text template, ready to be rendered
@@ -252,10 +252,10 @@ mod test {
             &tpl.blocks,
             &[
                 Block::new("", "person", Tag::Section).children(7),
-                Block::new("", "-last", Tag::Indexed(Indexed::Exclude(Last))).children(2),
+                Block::new("", "-last", Tag::Indexed(Indexed::Exclude(Index::Last))).children(2),
                 Block::new("", "name", Tag::Unescaped),
                 Block::nameless("", Tag::Closing),
-                Block::new("", "-last", Tag::Indexed(Indexed::Include(Last))).children(2),
+                Block::new("", "-last", Tag::Indexed(Indexed::Include(Index::Last))).children(2),
                 Block::new("", "name", Tag::Unescaped),
                 Block::nameless("", Tag::Closing),
                 Block::nameless("", Tag::Closing),


### PR DESCRIPTION
Hi! A simple fix for the public API. When using the `indexes` feature, both are necessary to
implement the `Content` trait.
