### PR TITLE
feat: add render_indexed_content_section for indexes feature

### DIFF
--- a/ramhorns/src/lib.rs
+++ b/ramhorns/src/lib.rs
@@ -89,6 +89,9 @@ pub use content::Content;
 pub use error::Error;
 pub use template::{Section, Template};
 
+#[cfg(feature = "indexes")]
+pub use content::render_indexed_content_section;
+
 #[cfg(feature = "export_derive")]
 pub use ramhorns_derive::Content;
 


### PR DESCRIPTION
Hi! Currently, implementing `render_section` with indexes feature would require writing an equivalent to `IndexedBasedReader`.
As the logic is likely to be the same all the time, I have added a `render_indexed_content_section` to handle this.

I'm not really sure if that's the best approach though.

Furthermore there was an inconsistency, except `Vec<T>`, all other list types like `&[T]` would simply ignore the `indexes` feature.
