### PR TITLE
Add support for dot notation for strings

### DIFF
--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -182,6 +182,47 @@ impl Content for str {
     fn render_unescaped<E: Encoder>(&self, encoder: &mut E) -> Result<(), E::Error> {
         encoder.write_unescaped(self)
     }
+
+    /// Supports `{{.}}` syntax to render the string inside a section
+    #[inline]
+    fn render_field_escaped<E: Encoder>(
+        &self,
+        _hash: u64,
+        name: &str,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error> {
+        match name {
+            "." => self.render_escaped(encoder).map(|_| true),
+            _ => Ok(false)
+        }
+    }
+
+    /// Supports `{{.}}` syntax to render the string inside a section
+    #[inline]
+    fn render_field_unescaped<E: Encoder>(
+        &self,
+        _hash: u64,
+        name: &str,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error> {
+        match name {
+            "." => self.render_unescaped(encoder).map(|_| true),
+            _ => Ok(false)
+        }
+    }
+
+    #[inline]
+    fn render_section<C, E>(&self, section: Section<C>, encoder: &mut E) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl Content for String {
@@ -203,6 +244,47 @@ impl Content for String {
     #[inline]
     fn render_unescaped<E: Encoder>(&self, encoder: &mut E) -> Result<(), E::Error> {
         encoder.write_unescaped(self)
+    }
+
+    /// Supports `{{.}}` syntax to render the string inside a section
+    #[inline]
+    fn render_field_escaped<E: Encoder>(
+        &self,
+        _hash: u64,
+        name: &str,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error> {
+        match name {
+            "." => self.render_escaped(encoder).map(|_| true),
+            _ => Ok(false)
+        }
+    }
+
+    /// Supports `{{.}}` syntax to render the string inside a section
+    #[inline]
+    fn render_field_unescaped<E: Encoder>(
+        &self,
+        _hash: u64,
+        name: &str,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error> {
+        match name {
+            "." => self.render_unescaped(encoder).map(|_| true),
+            _ => Ok(false)
+        }
+    }
+
+    #[inline]
+    fn render_section<C, E>(&self, section: Section<C>, encoder: &mut E) -> Result<(), E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        if self.is_truthy() {
+            section.with(self).render(encoder)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -403,10 +485,11 @@ impl<T: Content> Content for Vec<T> {
             .render_section(section, encoder)?;
         }
         #[cfg(not(feature = "indexes"))]
-        for item in self.iter() {
-            item.render_section(section, encoder)?;
+        {
+            for item in self.iter() {
+                item.render_section(section, encoder)?;
+            }
         }
-
         Ok(())
     }
 }

--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -183,7 +183,7 @@ impl Content for str {
         encoder.write_unescaped(self)
     }
 
-    /// Supports `{{.}}` syntax to render the string inside a section
+    /// Supports implicit iterator (`{{.}}`) to render the string inside a section
     #[inline]
     fn render_field_escaped<E: Encoder>(
         &self,
@@ -197,7 +197,7 @@ impl Content for str {
         }
     }
 
-    /// Supports `{{.}}` syntax to render the string inside a section
+    /// Supports implicit iterator (`{{.}}`) to render the string inside a section
     #[inline]
     fn render_field_unescaped<E: Encoder>(
         &self,
@@ -211,6 +211,7 @@ impl Content for str {
         }
     }
 
+    /// Supports implicit iterator (`{{.}}`) to render the string within a section
     #[inline]
     fn render_section<C, E>(&self, section: Section<C>, encoder: &mut E) -> Result<(), E::Error>
     where
@@ -221,6 +222,29 @@ impl Content for str {
             section.with(self).render(encoder)
         } else {
             Ok(())
+        }
+    }
+
+    /// Theoretically supports implicit iterator inverse (`{{^.}}fallback{{/.}}`)
+    /// to render a fallback if the string is empty within a section.
+    ///
+    /// *NOTE*: if the item is not [`truthy`](Content::is_truthy)
+    /// most sequences won't display the section at all,
+    /// making this syntax unusable (bar custom implementations of `Content`).
+    fn render_field_inverse<C, E>(
+        &self,
+        _hash: u64,
+        name: &str,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        match name {
+            "." => self.render_inverse(section, encoder).map(|_| true),
+            _ => Ok(false),
         }
     }
 }
@@ -246,7 +270,7 @@ impl Content for String {
         encoder.write_unescaped(self)
     }
 
-    /// Supports `{{.}}` syntax to render the string inside a section
+    /// Supports implicit iterator (`{{.}}`) to render the string inside a section
     #[inline]
     fn render_field_escaped<E: Encoder>(
         &self,
@@ -260,7 +284,7 @@ impl Content for String {
         }
     }
 
-    /// Supports `{{.}}` syntax to render the string inside a section
+    /// Supports implicit iterator (`{{.}}`) to render the string inside a section
     #[inline]
     fn render_field_unescaped<E: Encoder>(
         &self,
@@ -274,6 +298,7 @@ impl Content for String {
         }
     }
 
+    /// Supports implicit iterator (`{{.}}`) to render the string inside a section
     #[inline]
     fn render_section<C, E>(&self, section: Section<C>, encoder: &mut E) -> Result<(), E::Error>
     where
@@ -284,6 +309,29 @@ impl Content for String {
             section.with(self).render(encoder)
         } else {
             Ok(())
+        }
+    }
+
+    /// Theoretically supports implicit iterator inverse (`{{^.}}fallback{{/.}}`)
+    /// to render a fallback if the string is empty within a section.
+    ///
+    /// *NOTE*: if the item is not [`truthy`](Content::is_truthy)
+    /// most sequences won't display the section at all,
+    /// making this syntax unusable (bar custom implementations of `Content`).
+    fn render_field_inverse<C, E>(
+        &self,
+        _hash: u64,
+        name: &str,
+        section: Section<C>,
+        encoder: &mut E,
+    ) -> Result<bool, E::Error>
+    where
+        C: ContentSequence,
+        E: Encoder,
+    {
+        match name {
+            "." => self.render_inverse(section, encoder).map(|_| true),
+            _ => Ok(false),
         }
     }
 }

--- a/ramhorns/src/content.rs
+++ b/ramhorns/src/content.rs
@@ -533,10 +533,8 @@ impl<T: Content> Content for Vec<T> {
             .render_section(section, encoder)?;
         }
         #[cfg(not(feature = "indexes"))]
-        {
-            for item in self.iter() {
-                item.render_section(section, encoder)?;
-            }
+        for item in self.iter() {
+            item.render_section(section, encoder)?;
         }
         Ok(())
     }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -272,7 +272,32 @@ fn can_render_inverse_sections_for_empty_strs() {
 }
 
 #[test]
-fn can_render_dot_inside_sections_for_strs() {
+fn can_render_inverse_sections_for_empty_strs_in_list() {
+    #[derive(Content)]
+    struct Person<'a> {
+        name: &'a str,
+        last: bool,
+    }
+
+    #[derive(Content)]
+    struct Wrapper<'a> {
+        people: &'a [Person<'a>],
+    }
+
+    let tpl = Template::new("{{#people}}Hello {{name}}{{^name}}Anonymous{{/name}}!{{^last}}, {{/last}}{{/people}}").unwrap();
+
+    let rendered = tpl.render(&Wrapper {
+        people: &[
+            Person { name: "Maciej", last: false },
+            Person { name: "", last: true }
+        ]
+    });
+
+    assert_eq!(rendered, "Hello Maciej!, Hello Anonymous!");
+}
+
+#[test]
+fn can_render_implicit_iterator_for_strs_list() {
     #[derive(Content)]
     struct Post<'a> {
         tags: &'a [&'a str],
@@ -289,6 +314,124 @@ fn can_render_dot_inside_sections_for_strs() {
                               <li><a href=\"/post/tag/two\">two</a></li>\
                               <li><a href=\"/post/tag/three\">three</a></li>\
                           </ul>");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_for_single_list() {
+
+    let tpl = Template::new("<{{#.}} {{.}} {{/.}}>").unwrap();
+
+    let rendered = tpl.render(&["1", "2", "3"]);
+
+    assert_eq!(rendered, "<>");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_for_nested_lists() {
+
+    let tpl = Template::new("{{#.}}<{{#.}} {{.}} {{/.}}>{{/.}}").unwrap();
+
+    let rendered = tpl.render(&[&["1", "2", "3"], &["4", "5", "6"],]);
+
+    assert_eq!(rendered, "");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_for_arbitrary_content() {
+    #[derive(Content)]
+    struct Blog<'a> {
+        posts: &'a [Post<'a>],
+    }
+
+    #[derive(Content)]
+    struct Post<'a> {
+        tags: &'a [&'a str],
+        title: &'a str,
+        body: &'a str,
+    }
+
+    let tpl = Template::new("<h1>My Blog</h1>\
+                             <ul>{{#posts}}<li>{{.}}</li>{{/posts}}</ul>").unwrap();
+
+    let rendered = tpl.render(&Blog {
+        posts: &[
+            Post {
+                tags: &["one", "two", "three"],
+                title: "my post",
+                body: "hello and welcome...",
+            },
+            Post {
+                tags: &["one", "two"],
+                title: "my second post",
+                body: "yo",
+            }
+        ]
+    });
+
+    assert_eq!(rendered, "<h1>My Blog</h1>\
+                          <ul><li></li><li></li></ul>");
+}
+
+#[test]
+fn cannot_render_inverse_implicit_iterator_for_empty_strs() {
+    #[derive(Content)]
+    struct List<'a> {
+        items: &'a [&'a str],
+    }
+
+    // NOTE: This behavior *differs* from most implementations of mustache
+    // which would output: `oneEMPTYthree`
+    //
+    // empty strings are not rendered at all by their containers,
+    // so we don't see the `{{^.}}EMPTY{{/.}}` when rendering the empty string item below
+    // however, we do see it when rendering "one" and "three" and it will be hidden
+    let tpl = Template::new("{{#items}}{{^.}}EMPTY{{/.}}{{.}}{{/items}}").unwrap();
+
+    let rendered = tpl.render(&List { items: &["one", "", "three"] });
+
+    assert_eq!(rendered, "onethree");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_section_for_strs() {
+    #[derive(Content)]
+    struct List<'a> {
+        items: &'a [&'a str],
+    }
+
+    let tpl = Template::new("{{#items}}{{#.}}Not Rendered{{/.}}{{/items}}").unwrap();
+
+    let rendered = tpl.render(&List { items: &["one", "", "three"] });
+
+    assert_eq!(rendered, "");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_section_for_lists_of_strs() {
+
+    let tpl = Template::new("{{#.}}Hello {{.}}{{^.}}Anonymous{{/.}}! {{/.}}").unwrap();
+
+    let rendered = tpl.render(&["Maciej", ""]);
+
+    assert_eq!(rendered, "");
+}
+
+#[test]
+fn cannot_render_implicit_iterator_section_for_lists_of_derived_content() {
+    #[derive(Content)]
+    struct Person<'a> {
+        name: &'a str,
+        last: bool,
+    }
+
+    let tpl = Template::new("{{#.}}Hello {{name}}{{^name}}Anonymous{{/name}}!{{^last}}, {{/last}}{{/.}}").unwrap();
+
+    let rendered = tpl.render(&[
+        Person { name: "Maciej", last: false },
+        Person { name: "", last: true }
+    ]);
+
+    assert_eq!(rendered, "");
 }
 
 #[test]

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -272,6 +272,20 @@ fn can_render_inverse_sections_for_empty_strs() {
 }
 
 #[test]
+fn can_render_implicit_iterator_fallback_for_empty_lists_of_strs() {
+    #[derive(Content)]
+    struct Post<'a> {
+        tags: &'a [&'a str],
+    }
+
+    let tpl = Template::new("{{^tags}}No tags! implicit iterator='{{.}}'{{/tags}}").unwrap();
+
+    let rendered = tpl.render(&Post { tags: &[] });
+
+    assert_eq!(rendered, "No tags! implicit iterator=''");
+}
+
+#[test]
 fn can_render_inverse_sections_for_empty_strs_in_list() {
     #[derive(Content)]
     struct Person<'a> {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -272,6 +272,26 @@ fn can_render_inverse_sections_for_empty_strs() {
 }
 
 #[test]
+fn can_render_dot_inside_sections_for_strs() {
+    #[derive(Content)]
+    struct Post<'a> {
+        tags: &'a [&'a str],
+    }
+
+    let tpl = Template::new("<ul>{{#tags}}\
+                                 <li><a href=\"/post/tag/{{.}}\">{{.}}</a></li>{{/tags}}\
+                             </ul>").unwrap();
+
+    let rendered = tpl.render(&Post { tags: &["one", "two", "three"] });
+
+    assert_eq!(rendered, "<ul>\
+                              <li><a href=\"/post/tag/one\">one</a></li>\
+                              <li><a href=\"/post/tag/two\">two</a></li>\
+                              <li><a href=\"/post/tag/three\">three</a></li>\
+                          </ul>");
+}
+
+#[test]
 fn can_render_lists_from_slices() {
     #[derive(Content)]
     struct Article<'a> {


### PR DESCRIPTION
This fixes #42 without fully supporting #43.

I do think it would be possible to support opening/closing sections using `{{#.}}...{{/.}}`.
But I don't need that myself yet and it makes sense to keep this change simple for now.

The test shows a simple example inspired by the user who wanted to template a list of tags.

template
```mustache
<ul>{{#tags}}
   <li><a href=\"/post/tag/{{.}}\">{{.}}</a></li>{{/tags}}
</ul>
```

data
```
{ tags: ["one", "two", "three"] }
```

output
```html
<ul>
    <li><a href=\"/post/tag/one\">one</a></li>
    <li><a href=\"/post/tag/two\">two</a></li>
    <li><a href=\"/post/tag/three\">three</a></li>
</ul>
```

This matches what I see in the [mustache playground](https://jgonggrijp.gitlab.io/wontache/playground.html) as a sanity check.
You can paste the json below into the load/store input on the playground.

```
{"data":{"text":"{ tags: [\"one\", \"two\", \"three\"] }"},"templates":[{"name":"example1","text":"<ul>{{#tags}}\n    <li><a href=\\\"/post/tag/{{.}}\\\">{{.}}</a></li>{{/tags}}\n</ul>"}]}
```